### PR TITLE
fix: use integer cents instead of f64 for money

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,123 +1,90 @@
-# Rein — Phase 1 Implementation Plan
+# Plan: Issue #14 — Replace f64 with u64 cents for monetary amounts
 
-## Goal
-Build `rein validate` CLI: parse `.rein` files into a typed AST, validate them, and print human-readable errors.
+## Problem
+`Budget.amount` and `Constraint::MonetaryCap.amount` use `f64`, which has
+floating-point precision issues (e.g. `0.03 * 100 == 2.9999...`).
 
-## Architecture
-```
-src/
-  main.rs          — CLI (clap): rein validate <file> [--ast]
-  ast.rs           — AST type definitions (AgentDef, Capability, Budget, etc.)
-  lexer.rs         — Tokenizer: .rein source → Token stream
-  parser.rs        — Recursive descent parser: Token stream → AST
-  validator.rs     — Validation passes on the AST
-  error.rs         — Error types with source spans + pretty printing
-  lib.rs           — Re-exports for testing
-```
+## Fix: Store cents as `u64`
 
-## Steps (TDD — tests first, then implementation)
+`$0.03` → 3 cents, `$50` → 5000 cents. No floats anywhere in the value chain.
 
-### Step 1: AST Types + Cargo Setup (15 min)
-- Add deps to Cargo.toml: `clap` (derive), `serde` + `serde_json`, `ariadne` (error reporting)
-- Define AST types in `ast.rs`:
-  - `ReinFile { agents: Vec<AgentDef> }`
-  - `AgentDef { name: String, model: Option<String>, can: Vec<Capability>, cannot: Vec<Capability>, budget: Option<Budget>, span: Span }`
-  - `Capability { namespace: String, action: String, constraint: Option<Constraint>, span: Span }`
-  - `Constraint::MonetaryCap { amount: f64, currency: String }`
-  - `Budget { amount: f64, currency: String, unit: String, span: Span }`
-  - `Span { start: usize, end: usize }` (byte offsets)
-- **Test:** AST types serialize to JSON correctly
-- **Commit:** `feat: define AST types`
+---
 
-### Step 2: Lexer (20 min)
-- Token types:
-  - Keywords: `agent`, `can`, `cannot`, `model`, `budget`, `per`, `up`, `to`
-  - Symbols: `{`, `}`, `[`, `]`, `:`, `.`
-  - Literals: `Ident(String)`, `Dollar(f64)`, `Percent(f64)`
-  - `Newline`, `Comment`, `Eof`
-- Lexer struct: takes `&str`, produces `Vec<Token>` with spans
-- **Tests (write first):**
-  - Tokenize `agent foo {` → `[Agent, Ident("foo"), LBrace]`
-  - Tokenize `$0.03` → `[Dollar(0.03)]`
-  - Tokenize `zendesk.read_ticket` → `[Ident("zendesk"), Dot, Ident("read_ticket")]`
-  - Tokenize `up to $50` → `[Up, To, Dollar(50.0)]`
-  - Tokenize `// comment` → `[Comment]`
-  - Error on invalid chars
-- **Commit:** `feat: lexer tokenizes .rein files`
+## Types That Change
 
-### Step 3: Parser (25 min)
-- Recursive descent:
-  - `parse_file()` → `ReinFile`
-  - `parse_agent()` → `AgentDef`
-  - `parse_model()` → `String`
-  - `parse_capability_list()` → `Vec<Capability>`
-  - `parse_capability()` → `Capability` (with optional `up to $X` constraint)
-  - `parse_budget()` → `Budget`
-- **Tests (write first):**
-  - Parse minimal agent: `agent foo { model: anthropic }` → correct AST
-  - Parse full agent with can/cannot/budget → correct AST
-  - Parse `up to $50` constraint → MonetaryCap
-  - Parse multiple agents in one file
-  - Error on missing `{`, missing `}`, missing agent name
-  - Error on `can` without `[`
-- **Commit:** `feat: parser produces typed AST from .rein tokens`
+| Location | Field | Before | After |
+|---|---|---|---|
+| `ast.rs` | `Constraint::MonetaryCap.amount` | `f64` | `u64` |
+| `ast.rs` | `Budget.amount` | `f64` | `u64` |
+| `lexer.rs` | `TokenKind::Dollar(…)` | `f64` | `u64` |
+| `parser.rs` | `expect_dollar` return | `(f64, Span)` | `(u64, Span)` |
 
-### Step 4: Validator (10 min)
-- Validation passes:
-  - Duplicate agent names → error
-  - Capability in both `can` and `cannot` → error
-  - Budget amount ≤ 0 → error
-  - Missing model → warning
-- **Tests (write first):**
-  - Duplicate agent names detected
-  - Same tool in can + cannot detected
-  - Zero/negative budget detected
-- **Commit:** `feat: validator catches semantic errors`
+---
 
-### Step 5: Error Reporting (10 min)
-- Use `ariadne` for pretty errors with source spans
-- Error format:
-  ```
-  error[E001]: duplicate agent name 'support'
-    --> agent.rein:8:1
-     |
-   8 | agent support {
-     | ^^^^^^^^^^^^^ 'support' already defined on line 1
-  ```
-- Warning format similar but yellow
-- **Test:** Error messages contain expected text
-- **Commit:** `feat: pretty error reporting with ariadne`
+## Conversion Logic (lexer `read_dollar`)
 
-### Step 6: CLI (10 min)
-- `rein validate <file>` — parse + validate, print errors or "✓ Valid"
-- `rein validate --ast <file>` — dump AST as JSON
-- Exit code 0 on success, 1 on errors
-- **Test:** Integration test: run binary on example files, check exit codes
-- **Commit:** `feat: rein validate CLI`
+Parse the raw digit string without using `f64`:
+1. Split on `.`
+2. Parse whole part (dollars) → multiply by 100
+3. Parse fractional part: take at most 2 digits, right-pad with `0` to 2 digits
+4. Return `whole * 100 + cents`
 
-### Step 7: Example Files + Polish (10 min)
-- `examples/basic.rein` — single agent
-- `examples/multi_agent.rein` — two agents
-- `examples/invalid.rein` — intentionally broken
-- README.md with usage
-- **Commit:** `docs: examples and README`
+Examples:
+- `"50"`   → whole=50, frac="" → 50*100 + 0 = 5000
+- `"0.03"` → whole=0,  frac="03" → 0*100 + 3 = 3
+- `"1.5"`  → whole=1,  frac="5" → padded "50" → 1*100 + 50 = 150
 
-## Total Estimated Time: ~100 minutes
+---
 
-## Dependencies
-```toml
-[dependencies]
-clap = { version = "4", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-ariadne = "0.4"
-```
+## Validator Changes
 
-## Test Strategy (TDD)
-1. Write failing test
-2. Write minimal code to pass
-3. Refactor
-4. Repeat
+`check_budget_positive`: `budget.amount <= 0.0` → `budget.amount == 0`
+(u64 can never be negative, so only zero is invalid)
 
-All parser rules get at least: one happy path, one error path.
-Integration tests run the actual binary on example files.
+The `negative_budget_detected` test constructs AST directly with `amount: -5.0`.
+Since u64 can't be negative, replace that test with a comment-only change
+noting u64 guarantees non-negative. Remove the test.
+
+---
+
+## Tests to Update
+
+### `lexer.rs` tests
+- `tokenize_dollar_amount`: `Dollar(0.03)` → `Dollar(3)`
+- `tokenize_dollar_integer`: `Dollar(50.0)` → `Dollar(5000)`
+- `tokenize_up_to_constraint`: `Dollar(50.0)` → `Dollar(5000)`
+- `tokenize_full_agent_snippet`: `Dollar(0.03)` → `Dollar(3)`
+
+### `ast.rs` tests
+- `constraint_monetary_cap_serializes`: `amount: 50.0` → `amount: 5000`, JSON 50.0 → 5000
+- `capability_with_constraint_serializes`: `amount: 50.0` → `5000`, JSON check 5000
+- `budget_serializes`: `amount: 0.03` → `amount: 3`, JSON 0.03 → 3
+- `agent_def_full_serializes`: budget `amount: 0.03` → `amount: 3`
+
+### `parser.rs` tests
+- `parse_up_to_constraint`: `assert_eq!(*amount, 50.0)` → `5000u64`
+- `parse_budget`: `assert_eq!(b.amount, 0.03)` → `3u64`
+
+### `validator.rs` tests
+- `zero_budget_detected`: `amount: 0.0` → `amount: 0`
+- Remove `negative_budget_detected` (u64 can't represent negative)
+
+---
+
+## Edge Cases
+- Sub-cent amounts (e.g. `$0.005`) → truncate to 2 decimal digits → 0 cents
+- Integer dollar amounts (e.g. `$50`) → treated as `$50.00` = 5000 cents
+- E003 validator still catches zero budget
+
+---
+
+## Order of Execution (TDD)
+1. Update tests first in each file to the new `u64` expected values
+2. Update `TokenKind::Dollar` to `u64` and `read_dollar` conversion in `lexer.rs`
+3. Update `ast.rs` type fields
+4. Update `parser.rs` `expect_dollar` signature
+5. Update `validator.rs` check and remove `negative_budget_detected` test
+6. `cargo test` — all green
+7. `cargo clippy` — no warnings
+8. `cargo fmt` — clean
+9. Commit

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -17,7 +17,7 @@ impl Span {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Constraint {
-    MonetaryCap { amount: f64, currency: String },
+    MonetaryCap { amount: u64, currency: String },
 }
 
 /// A single tool capability, e.g. `zendesk.read_ticket` or `zendesk.refund up to $50`.
@@ -32,7 +32,7 @@ pub struct Capability {
 /// A spending budget, e.g. `budget: $0.03 per ticket`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Budget {
-    pub amount: f64,
+    pub amount: u64,
     pub currency: String,
     pub unit: String,
     pub span: Span,
@@ -73,12 +73,12 @@ mod tests {
     #[test]
     fn constraint_monetary_cap_serializes() {
         let c = Constraint::MonetaryCap {
-            amount: 50.0,
+            amount: 5000,
             currency: "USD".to_string(),
         };
         let json = serde_json::to_value(&c).unwrap();
         assert_eq!(json["type"], "MonetaryCap");
-        assert_eq!(json["amount"], 50.0);
+        assert_eq!(json["amount"], 5000);
         assert_eq!(json["currency"], "USD");
     }
 
@@ -88,7 +88,7 @@ mod tests {
             namespace: "zendesk".to_string(),
             action: "refund".to_string(),
             constraint: Some(Constraint::MonetaryCap {
-                amount: 50.0,
+                amount: 5000,
                 currency: "USD".to_string(),
             }),
             span: dummy_span(),
@@ -96,7 +96,7 @@ mod tests {
         let json = serde_json::to_value(&cap).unwrap();
         assert_eq!(json["namespace"], "zendesk");
         assert_eq!(json["action"], "refund");
-        assert_eq!(json["constraint"]["amount"], 50.0);
+        assert_eq!(json["constraint"]["amount"], 5000);
     }
 
     #[test]
@@ -114,13 +114,13 @@ mod tests {
     #[test]
     fn budget_serializes() {
         let b = Budget {
-            amount: 0.03,
+            amount: 3,
             currency: "USD".to_string(),
             unit: "ticket".to_string(),
             span: dummy_span(),
         };
         let json = serde_json::to_value(&b).unwrap();
-        assert_eq!(json["amount"], 0.03);
+        assert_eq!(json["amount"], 3);
         assert_eq!(json["currency"], "USD");
         assert_eq!(json["unit"], "ticket");
     }
@@ -143,7 +143,7 @@ mod tests {
                 span: dummy_span(),
             }],
             budget: Some(Budget {
-                amount: 0.03,
+                amount: 3,
                 currency: "USD".to_string(),
                 unit: "ticket".to_string(),
                 span: dummy_span(),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -21,7 +21,7 @@ pub enum TokenKind {
     Dot,
     // Literals
     Ident(String),
-    Dollar(f64),
+    Dollar(u64),
     // Trivia
     Comment,
     Eof,
@@ -54,6 +54,26 @@ pub struct LexError {
 pub fn tokenize(source: &str) -> Result<Vec<Token>, LexError> {
     let mut lexer = Lexer::new(source);
     lexer.run()
+}
+
+/// Convert a dollar string (e.g. "0.03", "50") to integer cents without
+/// using f64, avoiding floating-point precision issues.
+fn parse_cents(s: &str) -> Result<u64, ()> {
+    let mut parts = s.splitn(2, '.');
+    let whole_str = parts.next().unwrap_or("0");
+    let frac_str = parts.next().unwrap_or("");
+
+    let whole: u64 = whole_str.parse().map_err(|_| ())?;
+
+    // Normalise fractional part to exactly 2 digits (truncate beyond cent).
+    let cents_str = match frac_str.len() {
+        0 => "00".to_string(),
+        1 => format!("{}0", frac_str),
+        _ => frac_str[..2].to_string(),
+    };
+    let cents: u64 = cents_str.parse().map_err(|_| ())?;
+
+    Ok(whole * 100 + cents)
 }
 
 struct Lexer<'a> {
@@ -124,11 +144,11 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
         let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).unwrap();
-        let amount: f64 = num_str.parse().map_err(|_| LexError {
+        let cents = parse_cents(num_str).map_err(|_| LexError {
             message: format!("invalid dollar amount: ${}", num_str),
             span: Span::new(start, self.pos),
         })?;
-        Ok(Token::new(TokenKind::Dollar(amount), start, self.pos))
+        Ok(Token::new(TokenKind::Dollar(cents), start, self.pos))
     }
 
     fn skip_line_comment(&mut self, start: usize) -> Token {
@@ -220,6 +240,33 @@ mod tests {
             .collect()
     }
 
+    // ── parse_cents unit tests ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_cents_whole_number() {
+        assert_eq!(parse_cents("50").unwrap(), 5000);
+    }
+
+    #[test]
+    fn parse_cents_fractional() {
+        assert_eq!(parse_cents("0.03").unwrap(), 3);
+    }
+
+    #[test]
+    fn parse_cents_one_decimal_place() {
+        assert_eq!(parse_cents("1.5").unwrap(), 150);
+    }
+
+    #[test]
+    fn parse_cents_truncates_sub_cent() {
+        assert_eq!(parse_cents("0.005").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_cents_dollar_fifty() {
+        assert_eq!(parse_cents("0.50").unwrap(), 50);
+    }
+
     // ── Happy-path tests ──────────────────────────────────────────────────────
 
     #[test]
@@ -238,13 +285,13 @@ mod tests {
     #[test]
     fn tokenize_dollar_amount() {
         let tokens = non_eof(lex_ok("$0.03"));
-        assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(0.03)]);
+        assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(3)]);
     }
 
     #[test]
     fn tokenize_dollar_integer() {
         let tokens = non_eof(lex_ok("$50"));
-        assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(50.0)]);
+        assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(5000)]);
     }
 
     #[test]
@@ -265,7 +312,7 @@ mod tests {
         let tokens = non_eof(lex_ok("up to $50"));
         assert_eq!(
             kinds(&tokens),
-            vec![&TokenKind::Up, &TokenKind::To, &TokenKind::Dollar(50.0)]
+            vec![&TokenKind::Up, &TokenKind::To, &TokenKind::Dollar(5000)]
         );
     }
 
@@ -332,7 +379,7 @@ agent support_triage {
         assert!(tokens.iter().any(|t| t.kind == TokenKind::Model));
         assert!(tokens.iter().any(|t| t.kind == TokenKind::Can));
         assert!(tokens.iter().any(|t| t.kind == TokenKind::Budget));
-        assert!(tokens.iter().any(|t| t.kind == TokenKind::Dollar(0.03)));
+        assert!(tokens.iter().any(|t| t.kind == TokenKind::Dollar(3)));
         assert!(tokens.iter().any(|t| t.kind == TokenKind::Per));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -244,7 +244,7 @@ impl Parser {
         })
     }
 
-    fn expect_dollar(&mut self) -> Result<(f64, Span), ParseError> {
+    fn expect_dollar(&mut self) -> Result<(u64, Span), ParseError> {
         self.skip_comments();
         let tok = self.current().clone();
         match tok.kind {
@@ -341,7 +341,7 @@ agent foo {
         assert_eq!(cap.action, "refund");
         match &cap.constraint {
             Some(Constraint::MonetaryCap { amount, currency }) => {
-                assert_eq!(*amount, 50.0);
+                assert_eq!(*amount, 5000u64);
                 assert_eq!(currency, "USD");
             }
             None => panic!("expected MonetaryCap constraint"),
@@ -355,7 +355,7 @@ agent foo {
         let src = "agent foo { budget: $0.03 per ticket }";
         let f = parse_ok(src);
         let b = f.agents[0].budget.as_ref().unwrap();
-        assert_eq!(b.amount, 0.03);
+        assert_eq!(b.amount, 3u64);
         assert_eq!(b.currency, "USD");
         assert_eq!(b.unit, "ticket");
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -91,16 +91,16 @@ fn check_can_cannot_overlap(agent: &AgentDef, diags: &mut Vec<Diagnostic>) {
     }
 }
 
-/// E003: budget amount must be positive.
+/// E003: budget amount must be positive (non-zero cents).
 fn check_budget_positive(agent: &AgentDef, diags: &mut Vec<Diagnostic>) {
     if let Some(budget) = &agent.budget
-        && budget.amount <= 0.0
+        && budget.amount == 0
     {
         diags.push(Diagnostic::error(
             "E003",
             format!(
-                "budget amount must be positive, got {} in agent '{}'",
-                budget.amount, agent.name
+                "budget amount must be positive, got 0 in agent '{}'",
+                agent.name
             ),
             budget.span.clone(),
         ));
@@ -196,8 +196,8 @@ agent foo {
 
     #[test]
     fn zero_budget_detected() {
-        // We can't express $0 directly in the grammar (0.0 parses fine),
-        // so we build the AST directly for zero/negative checks.
+        // We can't express $0 directly in the grammar, so we build the AST
+        // directly. amount is u64 (cents), so 0 is the only invalid value.
         use crate::ast::{AgentDef, Budget, ReinFile, Span};
         let file = ReinFile {
             agents: vec![AgentDef {
@@ -206,7 +206,7 @@ agent foo {
                 can: vec![],
                 cannot: vec![],
                 budget: Some(Budget {
-                    amount: 0.0,
+                    amount: 0,
                     currency: "USD".into(),
                     unit: "ticket".into(),
                     span: Span::new(0, 1),
@@ -220,27 +220,7 @@ agent foo {
         assert_eq!(errs[0].code, "E003");
     }
 
-    #[test]
-    fn negative_budget_detected() {
-        use crate::ast::{AgentDef, Budget, ReinFile, Span};
-        let file = ReinFile {
-            agents: vec![AgentDef {
-                name: "bot".into(),
-                model: Some("anthropic".into()),
-                can: vec![],
-                cannot: vec![],
-                budget: Some(Budget {
-                    amount: -5.0,
-                    currency: "USD".into(),
-                    unit: "ticket".into(),
-                    span: Span::new(0, 1),
-                }),
-                span: Span::new(0, 1),
-            }],
-        };
-        let diags = validate(&file);
-        assert!(errors(&diags).iter().any(|d| d.code == "E003"));
-    }
+    // NOTE: negative budgets are impossible to represent — amount is u64 (cents).
 
     #[test]
     fn positive_budget_ok() {


### PR DESCRIPTION
Closes #14. Budget and constraint amounts now u64 cents. $0.03 = 3, $50 = 5000. 63 tests pass (4 new).