### PR TITLE
feat: add string literal support for model names

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -21,6 +21,7 @@ pub enum TokenKind {
     Dot,
     // Literals
     Ident(String),
+    StringLiteral(String),
     Dollar(u64),
     // Trivia
     Comment,
@@ -216,6 +217,24 @@ impl<'a> Lexer<'a> {
         Ok(Token::new(TokenKind::Dollar(cents), start, self.pos))
     }
 
+    fn read_string(&mut self, start: usize) -> Result<Token, LexError> {
+        // Opening '"' already consumed; collect content until closing '"'.
+        let mut value = String::new();
+        loop {
+            match self.advance() {
+                None => {
+                    return Err(LexError {
+                        message: "unterminated string literal".to_string(),
+                        span: Span::new(start, self.pos),
+                    });
+                }
+                Some(b'"') => break,
+                Some(ch) => value.push(ch as char),
+            }
+        }
+        Ok(Token::new(TokenKind::StringLiteral(value), start, self.pos))
+    }
+
     fn skip_line_comment(&mut self, start: usize) -> Token {
         while !matches!(self.peek(), Some(b'\n') | None) {
             self.advance();
@@ -262,6 +281,7 @@ impl<'a> Lexer<'a> {
                 Some(b']') => tokens.push(Token::new(TokenKind::RBracket, start, self.pos)),
                 Some(b':') => tokens.push(Token::new(TokenKind::Colon, start, self.pos)),
                 Some(b'.') => tokens.push(Token::new(TokenKind::Dot, start, self.pos)),
+                Some(b'"') => tokens.push(self.read_string(start)?),
                 Some(b'$') => tokens.push(self.read_dollar(start)?),
                 Some(b'/') if self.peek() == Some(b'/') => {
                     self.advance(); // second '/'
@@ -460,6 +480,52 @@ agent support_triage {
     fn eof_is_always_last() {
         let tokens = lex_ok("agent foo {}");
         assert_eq!(tokens.last().unwrap().kind, TokenKind::Eof);
+    }
+
+    // ── String literal tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn tokenize_string_literal_simple() {
+        let tokens = non_eof(lex_ok(r#""anthropic""#));
+        assert_eq!(
+            kinds(&tokens),
+            vec![&TokenKind::StringLiteral("anthropic".into())]
+        );
+    }
+
+    #[test]
+    fn tokenize_string_literal_with_slash() {
+        let tokens = non_eof(lex_ok(r#""anthropic/claude-3-sonnet""#));
+        assert_eq!(
+            kinds(&tokens),
+            vec![&TokenKind::StringLiteral(
+                "anthropic/claude-3-sonnet".into()
+            )]
+        );
+    }
+
+    #[test]
+    fn tokenize_empty_string_literal() {
+        let tokens = non_eof(lex_ok(r#""""#));
+        assert_eq!(kinds(&tokens), vec![&TokenKind::StringLiteral("".into())]);
+    }
+
+    #[test]
+    fn tokenize_string_literal_span() {
+        let src = r#""hello""#;
+        let tokens = lex_ok(src);
+        let tok = tokens
+            .iter()
+            .find(|t| matches!(t.kind, TokenKind::StringLiteral(_)))
+            .unwrap();
+        // span covers the full `"hello"` including quotes
+        assert_eq!(tok.span, Span::new(0, 7));
+    }
+
+    #[test]
+    fn error_unterminated_string_literal() {
+        let err = tokenize(r#""not closed"#).unwrap_err();
+        assert!(err.message.contains("unterminated"), "got: {}", err.message);
     }
 
     // ── Error-path tests ──────────────────────────────────────────────────────

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,6 +95,31 @@ impl Parser {
         }
     }
 
+    /// Consume an `Ident` or `StringLiteral` token as a model name and return its value.
+    fn expect_model_value(&mut self) -> Result<String, ParseError> {
+        self.skip_comments();
+        let tok = self.current().clone();
+        match &tok.kind {
+            TokenKind::Ident(name) => {
+                let name = name.clone();
+                self.advance();
+                Ok(name)
+            }
+            TokenKind::StringLiteral(s) => {
+                let s = s.clone();
+                self.advance();
+                Ok(s)
+            }
+            _ => Err(ParseError::new(
+                format!(
+                    "expected model name (identifier or string literal), got {:?}",
+                    tok.kind
+                ),
+                tok.span,
+            )),
+        }
+    }
+
     /// Consume an `Ident` token and return its string value + span.
     fn expect_ident(&mut self) -> Result<(String, Span), ParseError> {
         self.skip_comments();
@@ -173,8 +198,8 @@ impl Parser {
                     seen_model = true;
                     self.advance(); // consume `model`
                     self.expect(&TokenKind::Colon)?;
-                    // model value is an ident (e.g. `anthropic`)
-                    let (value, _) = self.expect_ident()?;
+                    // model value: bare ident or quoted string literal
+                    let value = self.expect_model_value()?;
                     model = Some(value);
                 }
                 TokenKind::Can => {
@@ -318,6 +343,37 @@ mod tests {
 
     fn parse_err(src: &str) -> ParseError {
         parse(src).expect_err("expected parse to fail")
+    }
+
+    // ── String literal model values ───────────────────────────────────────────
+
+    #[test]
+    fn parse_model_as_string_literal() {
+        let f = parse_ok(r#"agent foo { model: "anthropic/claude-3-sonnet" }"#);
+        assert_eq!(
+            f.agents[0].model.as_deref(),
+            Some("anthropic/claude-3-sonnet")
+        );
+    }
+
+    #[test]
+    fn parse_model_string_literal_with_dashes() {
+        let f = parse_ok(r#"agent foo { model: "gpt-4o" }"#);
+        assert_eq!(f.agents[0].model.as_deref(), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn parse_model_ident_still_works() {
+        // Bare identifier must continue to work alongside string literals.
+        let f = parse_ok("agent foo { model: anthropic }");
+        assert_eq!(f.agents[0].model.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn error_model_invalid_value() {
+        // A dollar amount is neither an ident nor a string — must error.
+        let err = parse_err("agent foo { model: $5 }");
+        assert!(err.message.contains("model name"), "got: {}", err.message);
     }
 
     // ── Minimal agent ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #20. Adds StringLiteral token type and parser support for quoted model values like "gpt-4o".