### PR TITLE
feat: create rein run CLI command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod run;
 pub mod validate;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,37 @@
+pub fn run_agent(path: &std::path::Path, message: Option<&str>) -> i32 {
+    let filename = path.to_string_lossy();
+
+    let source = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: cannot read '{filename}': {e}");
+            return 1;
+        }
+    };
+
+    let file = match rein::parser::parse(&source) {
+        Ok(f) => f,
+        Err(e) => {
+            rein::error::report_parse_error(&filename, &source, &e);
+            return 1;
+        }
+    };
+
+    let diags = rein::validator::validate(&file);
+    let has_errors = diags.iter().any(rein::validator::Diagnostic::is_error);
+
+    for diag in &diags {
+        rein::error::report_diagnostic(&filename, &source, diag);
+    }
+
+    if has_errors {
+        return 1;
+    }
+
+    if let Some(msg) = message {
+        println!("Message: {msg}");
+    }
+
+    println!("Runtime not yet implemented");
+    0
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,14 @@ enum Command {
         #[arg(long)]
         ast: bool,
     },
+    /// Run an agent defined in a .rein file
+    Run {
+        /// Path to the .rein file
+        file: std::path::PathBuf,
+        /// User prompt message to send to the agent
+        #[arg(short, long)]
+        message: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -28,6 +36,10 @@ async fn main() {
     match cli.command {
         Command::Validate { file, ast } => {
             let exit_code = commands::validate::run_validate(&file, ast);
+            process::exit(exit_code);
+        }
+        Command::Run { file, message } => {
+            let exit_code = commands::run::run_agent(&file, message.as_deref());
             process::exit(exit_code);
         }
     }


### PR DESCRIPTION
Closes #39. Adds run subcommand with --message flag. Parses/validates .rein file before execution.