### PR TITLE
feat: tool registry from .rein capabilities

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+pub mod permissions;
+
 use serde::{Deserialize, Serialize};
 
 /// A tool invocation requested by the agent.

--- a/src/runtime/permissions.rs
+++ b/src/runtime/permissions.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+use crate::ast::{AgentDef, Constraint};
+
+/// Returned when a tool call is blocked by the registry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PermissionDenied {
+    pub reason: String,
+}
+
+impl std::fmt::Display for PermissionDenied {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "permission denied: {}", self.reason)
+    }
+}
+
+impl std::error::Error for PermissionDenied {}
+
+/// A monetary cap attached to an allowed capability (`up to $<amount>`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MonetaryCap {
+    /// Amount in the smallest currency unit (e.g. cents for USD).
+    pub amount: u64,
+    pub currency: String,
+}
+
+/// Internal classification of a tool's permission status.
+#[derive(Debug)]
+enum ToolEntry {
+    Allowed { cap: Option<MonetaryCap> },
+    Denied,
+}
+
+/// Registry of allowed/denied tools built from an [`AgentDef`]'s `can`/`cannot` lists.
+///
+/// Tools not present in either list are **default-denied**.
+/// If a tool appears in both lists, `cannot` takes precedence.
+#[derive(Debug)]
+pub struct ToolRegistry {
+    /// Key is `"namespace.action"`.
+    tools: HashMap<String, ToolEntry>,
+}
+
+impl ToolRegistry {
+    /// Build a registry from a parsed agent definition.
+    pub fn from_agent(agent: &AgentDef) -> Self {
+        let mut tools = HashMap::new();
+
+        for cap in &agent.can {
+            let monetary_cap = cap.constraint.as_ref().map(|c| match c {
+                Constraint::MonetaryCap { amount, currency } => MonetaryCap {
+                    amount: *amount,
+                    currency: currency.clone(),
+                },
+            });
+            tools.insert(
+                Self::key(&cap.namespace, &cap.action),
+                ToolEntry::Allowed { cap: monetary_cap },
+            );
+        }
+
+        // `cannot` overrides `can` when both list the same tool.
+        for cap in &agent.cannot {
+            tools.insert(Self::key(&cap.namespace, &cap.action), ToolEntry::Denied);
+        }
+
+        Self { tools }
+    }
+
+    /// Check whether `namespace.action` is permitted.
+    ///
+    /// Returns `Ok(())` if the tool is in the `can` list.
+    /// Returns `Err` if the tool is in the `cannot` list or in neither list.
+    pub fn check_permission(&self, namespace: &str, action: &str) -> Result<(), PermissionDenied> {
+        match self.tools.get(&Self::key(namespace, action)) {
+            Some(ToolEntry::Allowed { .. }) => Ok(()),
+            Some(ToolEntry::Denied) => Err(PermissionDenied {
+                reason: format!("`{namespace}.{action}` is explicitly listed in the cannot block"),
+            }),
+            None => Err(PermissionDenied {
+                reason: format!("`{namespace}.{action}` is not in the can list (default deny)"),
+            }),
+        }
+    }
+
+    /// Returns the monetary cap for an allowed tool, if one was declared.
+    ///
+    /// Returns `None` for denied or unknown tools, and for allowed tools with
+    /// no constraint.
+    pub fn monetary_cap(&self, namespace: &str, action: &str) -> Option<&MonetaryCap> {
+        match self.tools.get(&Self::key(namespace, action)) {
+            Some(ToolEntry::Allowed { cap }) => cap.as_ref(),
+            _ => None,
+        }
+    }
+
+    fn key(namespace: &str, action: &str) -> String {
+        format!("{namespace}.{action}")
+    }
+}

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1,5 +1,183 @@
 use super::*;
 
+// ── ToolRegistry / permissions ─────────────────────────────────────────────
+
+mod permissions_tests {
+    use crate::ast::{AgentDef, Capability, Constraint, Span};
+    use crate::runtime::permissions::{MonetaryCap, PermissionDenied, ToolRegistry};
+
+    fn span() -> Span {
+        Span::new(0, 1)
+    }
+
+    fn cap(namespace: &str, action: &str) -> Capability {
+        Capability {
+            namespace: namespace.into(),
+            action: action.into(),
+            constraint: None,
+            span: span(),
+        }
+    }
+
+    fn cap_with_monetary(namespace: &str, action: &str, amount: u64, currency: &str) -> Capability {
+        Capability {
+            namespace: namespace.into(),
+            action: action.into(),
+            constraint: Some(Constraint::MonetaryCap {
+                amount,
+                currency: currency.into(),
+            }),
+            span: span(),
+        }
+    }
+
+    fn agent(can: Vec<Capability>, cannot: Vec<Capability>) -> AgentDef {
+        AgentDef {
+            name: "test_agent".into(),
+            model: None,
+            can,
+            cannot,
+            budget: None,
+            span: span(),
+        }
+    }
+
+    #[test]
+    fn allowed_tool_passes() {
+        let registry =
+            ToolRegistry::from_agent(&agent(vec![cap("zendesk", "read_ticket")], vec![]));
+        assert!(registry.check_permission("zendesk", "read_ticket").is_ok());
+    }
+
+    #[test]
+    fn denied_tool_is_blocked() {
+        let registry =
+            ToolRegistry::from_agent(&agent(vec![], vec![cap("zendesk", "delete_ticket")]));
+        let err = registry
+            .check_permission("zendesk", "delete_ticket")
+            .unwrap_err();
+        assert!(
+            err.reason.contains("cannot"),
+            "expected 'cannot' in reason, got: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn unknown_tool_is_default_denied() {
+        let registry =
+            ToolRegistry::from_agent(&agent(vec![cap("zendesk", "read_ticket")], vec![]));
+        let err = registry
+            .check_permission("zendesk", "delete_ticket")
+            .unwrap_err();
+        assert!(
+            err.reason.contains("default deny"),
+            "expected 'default deny' in reason, got: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn empty_agent_denies_all() {
+        let registry = ToolRegistry::from_agent(&agent(vec![], vec![]));
+        let err = registry.check_permission("any", "tool").unwrap_err();
+        assert!(err.reason.contains("default deny"));
+    }
+
+    #[test]
+    fn monetary_cap_is_tracked() {
+        let registry = ToolRegistry::from_agent(&agent(
+            vec![cap_with_monetary("zendesk", "refund", 5000, "USD")],
+            vec![],
+        ));
+        assert!(registry.check_permission("zendesk", "refund").is_ok());
+        let mc = registry
+            .monetary_cap("zendesk", "refund")
+            .expect("cap present");
+        assert_eq!(mc.amount, 5000);
+        assert_eq!(mc.currency, "USD");
+    }
+
+    #[test]
+    fn unconstrained_tool_has_no_monetary_cap() {
+        let registry =
+            ToolRegistry::from_agent(&agent(vec![cap("zendesk", "read_ticket")], vec![]));
+        assert!(registry.monetary_cap("zendesk", "read_ticket").is_none());
+    }
+
+    #[test]
+    fn cannot_overrides_can_for_same_tool() {
+        let registry = ToolRegistry::from_agent(&agent(
+            vec![cap("zendesk", "read_ticket")],
+            vec![cap("zendesk", "read_ticket")],
+        ));
+        let err = registry
+            .check_permission("zendesk", "read_ticket")
+            .unwrap_err();
+        assert!(err.reason.contains("cannot"));
+    }
+
+    #[test]
+    fn monetary_cap_absent_for_denied_tool() {
+        let registry = ToolRegistry::from_agent(&agent(
+            vec![],
+            vec![cap_with_monetary("stripe", "charge", 1000, "USD")],
+        ));
+        assert!(registry.monetary_cap("stripe", "charge").is_none());
+    }
+
+    #[test]
+    fn multiple_can_tools_all_allowed() {
+        let registry = ToolRegistry::from_agent(&agent(
+            vec![
+                cap("zendesk", "read_ticket"),
+                cap("zendesk", "reply_ticket"),
+                cap("stripe", "read_charge"),
+            ],
+            vec![],
+        ));
+        assert!(registry.check_permission("zendesk", "read_ticket").is_ok());
+        assert!(registry.check_permission("zendesk", "reply_ticket").is_ok());
+        assert!(registry.check_permission("stripe", "read_charge").is_ok());
+        assert!(
+            registry
+                .check_permission("stripe", "delete_charge")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn permission_denied_display_contains_reason() {
+        let denied = PermissionDenied {
+            reason: "test reason".into(),
+        };
+        let s = denied.to_string();
+        assert!(s.contains("test reason"), "got: {s}");
+    }
+
+    #[test]
+    fn permission_denied_implements_error() {
+        fn accepts_error(_: &dyn std::error::Error) {}
+        let denied = PermissionDenied {
+            reason: "boom".into(),
+        };
+        accepts_error(&denied);
+    }
+
+    #[test]
+    fn monetary_cap_partial_eq() {
+        let a = MonetaryCap {
+            amount: 100,
+            currency: "USD".into(),
+        };
+        let b = MonetaryCap {
+            amount: 100,
+            currency: "USD".into(),
+        };
+        assert_eq!(a, b);
+    }
+}
+
 // ── ToolCall serialization ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #44. Permission enforcement with default-deny, monetary cap tracking.