### PR TITLE
feat: provider trait abstraction with mock. Closes #42

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod permissions;
+pub mod provider;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/runtime/provider/mod.rs
+++ b/src/runtime/provider/mod.rs
@@ -1,0 +1,190 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[cfg(test)]
+mod tests;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A role in a conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// A single message in a conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+    /// When role == Tool, the id of the tool call this is responding to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+impl Message {
+    #[must_use]
+    pub fn system(content: impl Into<String>) -> Self {
+        Self { role: Role::System, content: content.into(), tool_call_id: None }
+    }
+
+    #[must_use]
+    pub fn user(content: impl Into<String>) -> Self {
+        Self { role: Role::User, content: content.into(), tool_call_id: None }
+    }
+
+    #[must_use]
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self { role: Role::Assistant, content: content.into(), tool_call_id: None }
+    }
+
+    #[must_use]
+    pub fn tool(call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self { role: Role::Tool, content: content.into(), tool_call_id: Some(call_id.into()) }
+    }
+}
+
+/// A tool definition exposed to the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    /// JSON Schema for the tool's parameters.
+    pub parameters: serde_json::Value,
+}
+
+/// A tool call requested by the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallRequest {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// Token usage from a single LLM call.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// The response from a chat completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatResponse {
+    /// Text content of the assistant reply (may be empty if only tool calls).
+    pub content: String,
+    /// Tool calls the model wants to make.
+    pub tool_calls: Vec<ToolCallRequest>,
+    /// Token usage.
+    pub usage: Usage,
+    /// The model string returned by the provider.
+    pub model: String,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur when calling a provider.
+#[derive(Debug)]
+pub enum ProviderError {
+    /// HTTP or network error.
+    Network(String),
+    /// The provider returned a non-success status.
+    Api { status: u16, body: String },
+    /// Could not parse the provider response.
+    Parse(String),
+    /// Authentication failed (bad or missing key).
+    Auth(String),
+    /// Rate limited.
+    RateLimited,
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Network(msg) => write!(f, "network error: {msg}"),
+            Self::Api { status, body } => write!(f, "API error ({status}): {body}"),
+            Self::Parse(msg) => write!(f, "parse error: {msg}"),
+            Self::Auth(msg) => write!(f, "auth error: {msg}"),
+            Self::RateLimited => write!(f, "rate limited"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+// ---------------------------------------------------------------------------
+// Provider trait
+// ---------------------------------------------------------------------------
+
+/// An LLM provider that can complete chat conversations.
+#[allow(async_fn_in_trait)]
+pub trait Provider: Send + Sync {
+    /// Send a chat completion request.
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<ChatResponse, ProviderError>;
+
+    /// Return the provider name (e.g. "openai", "anthropic").
+    fn name(&self) -> &'static str;
+}
+
+// ---------------------------------------------------------------------------
+// Mock provider (for testing)
+// ---------------------------------------------------------------------------
+
+/// A mock provider that returns pre-configured responses.
+#[derive(Debug, Default)]
+pub struct MockProvider {
+    responses: std::sync::Mutex<Vec<Result<ChatResponse, String>>>,
+}
+
+impl MockProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queue a successful response.
+    pub fn push_response(&self, response: ChatResponse) {
+        self.responses.lock().expect("lock poisoned").push(Ok(response));
+    }
+
+    /// Queue an error response.
+    pub fn push_error(&self, msg: impl Into<String>) {
+        self.responses.lock().expect("lock poisoned").push(Err(msg.into()));
+    }
+}
+
+impl Provider for MockProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolDef],
+    ) -> Result<ChatResponse, ProviderError> {
+        let mut queue = self.responses.lock().expect("lock poisoned");
+        if queue.is_empty() {
+            return Err(ProviderError::Api {
+                status: 500,
+                body: "no mock responses queued".to_string(),
+            });
+        }
+        match queue.remove(0) {
+            Ok(resp) => Ok(resp),
+            Err(msg) => Err(ProviderError::Network(msg)),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+}

--- a/src/runtime/provider/tests.rs
+++ b/src/runtime/provider/tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+#[test]
+fn message_constructors() {
+    let sys = Message::system("hello");
+    assert_eq!(sys.role, Role::System);
+    assert_eq!(sys.content, "hello");
+    assert!(sys.tool_call_id.is_none());
+
+    let user = Message::user("question");
+    assert_eq!(user.role, Role::User);
+
+    let asst = Message::assistant("answer");
+    assert_eq!(asst.role, Role::Assistant);
+
+    let tool = Message::tool("call-1", "result");
+    assert_eq!(tool.role, Role::Tool);
+    assert_eq!(tool.tool_call_id.as_deref(), Some("call-1"));
+}
+
+#[test]
+fn tool_def_serializes() {
+    let def = ToolDef {
+        name: "read_file".to_string(),
+        description: "Read a file".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" }
+            }
+        }),
+    };
+    let json = serde_json::to_string(&def).expect("serialize");
+    assert!(json.contains("read_file"));
+}
+
+#[test]
+fn usage_default() {
+    let u = Usage::default();
+    assert_eq!(u.input_tokens, 0);
+    assert_eq!(u.output_tokens, 0);
+}
+
+#[tokio::test]
+async fn mock_provider_returns_queued_response() {
+    let mock = MockProvider::new();
+    mock.push_response(ChatResponse {
+        content: "Hello!".to_string(),
+        tool_calls: vec![],
+        usage: Usage { input_tokens: 10, output_tokens: 5 },
+        model: "mock-1".to_string(),
+    });
+
+    let resp = mock.chat(&[Message::user("Hi")], &[]).await.expect("should succeed");
+    assert_eq!(resp.content, "Hello!");
+    assert_eq!(resp.usage.input_tokens, 10);
+    assert_eq!(resp.model, "mock-1");
+}
+
+#[tokio::test]
+async fn mock_provider_returns_queued_error() {
+    let mock = MockProvider::new();
+    mock.push_error("connection refused");
+
+    let err = mock.chat(&[Message::user("Hi")], &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("connection refused"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn mock_provider_empty_queue_errors() {
+    let mock = MockProvider::new();
+    let err = mock.chat(&[Message::user("Hi")], &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("no mock responses"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn mock_provider_multiple_responses_in_order() {
+    let mock = MockProvider::new();
+    mock.push_response(ChatResponse {
+        content: "first".to_string(),
+        tool_calls: vec![],
+        usage: Usage::default(),
+        model: "mock-1".to_string(),
+    });
+    mock.push_response(ChatResponse {
+        content: "second".to_string(),
+        tool_calls: vec![],
+        usage: Usage::default(),
+        model: "mock-1".to_string(),
+    });
+
+    let r1 = mock.chat(&[Message::user("1")], &[]).await.expect("first");
+    let r2 = mock.chat(&[Message::user("2")], &[]).await.expect("second");
+    assert_eq!(r1.content, "first");
+    assert_eq!(r2.content, "second");
+}
+
+#[test]
+fn mock_provider_name() {
+    let mock = MockProvider::new();
+    assert_eq!(mock.name(), "mock");
+}
+
+#[test]
+fn provider_error_display() {
+    assert_eq!(ProviderError::Network("timeout".into()).to_string(), "network error: timeout");
+    assert_eq!(
+        ProviderError::Api { status: 429, body: "slow down".into() }.to_string(),
+        "API error (429): slow down"
+    );
+    assert_eq!(ProviderError::Parse("bad json".into()).to_string(), "parse error: bad json");
+    assert_eq!(ProviderError::Auth("invalid key".into()).to_string(), "auth error: invalid key");
+    assert_eq!(ProviderError::RateLimited.to_string(), "rate limited");
+}
+
+#[test]
+fn chat_response_with_tool_calls() {
+    let resp = ChatResponse {
+        content: String::new(),
+        tool_calls: vec![
+            ToolCallRequest {
+                id: "call-1".to_string(),
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({"path": "/tmp/test"}),
+            },
+        ],
+        usage: Usage { input_tokens: 100, output_tokens: 50 },
+        model: "gpt-4".to_string(),
+    };
+    assert!(resp.content.is_empty());
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].name, "read_file");
+}


### PR DESCRIPTION
## Summary
- Async `Provider` trait with `chat()` and `name()` methods
- Types: `Message`, `ChatResponse`, `ToolDef`, `ToolCallRequest`, `Usage`, `Role`
- `ProviderError` enum (Network, Api, Parse, Auth, RateLimited)
- `MockProvider` for testing with queueable responses
- 10 new tests, all passing
- Zero clippy warnings

Closes #42