### PR TITLE
feat: agent execution engine + mock executor. Closes #49, #50

### DIFF
--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -1,0 +1,247 @@
+use super::budget::{BudgetTracker, calculate_cost};
+use super::executor::ToolExecutor;
+use super::interceptor::{InterceptResult, ToolInterceptor};
+use super::permissions::ToolRegistry;
+use super::provider::{Message, Provider, ToolCallRequest, ToolDef};
+use super::{RunError, RunEvent, RunTrace, ToolCall};
+
+#[cfg(test)]
+mod tests;
+
+/// Configuration for an agent run.
+#[derive(Debug, Clone)]
+pub struct RunConfig {
+    /// System prompt to prepend.
+    pub system_prompt: Option<String>,
+    /// Maximum number of LLM round-trips before stopping.
+    pub max_turns: usize,
+    /// Budget limit in cents (0 = no budget).
+    pub budget_cents: u64,
+}
+
+impl Default for RunConfig {
+    fn default() -> Self {
+        Self {
+            system_prompt: None,
+            max_turns: 10,
+            budget_cents: 0,
+        }
+    }
+}
+
+/// The result of a completed agent run.
+#[derive(Debug)]
+pub struct RunResult {
+    /// Final assistant response text.
+    pub response: String,
+    /// Full trace of events.
+    pub trace: RunTrace,
+    /// Total tokens used.
+    pub total_tokens: u64,
+    /// Total cost in cents.
+    pub total_cost_cents: u64,
+}
+
+/// Mutable state carried through the agent loop.
+struct RunState {
+    messages: Vec<Message>,
+    events: Vec<RunEvent>,
+    total_tokens: u64,
+    total_cost_cents: u64,
+    budget: Option<BudgetTracker>,
+}
+
+/// The agent execution engine. Orchestrates the LLM, tool call, result loop
+/// while enforcing permissions and budget constraints from the `.rein` file.
+pub struct AgentEngine<'a> {
+    provider: &'a dyn Provider,
+    executor: &'a dyn ToolExecutor,
+    interceptor: ToolInterceptor<'a>,
+    tool_defs: Vec<ToolDef>,
+    config: RunConfig,
+}
+
+impl<'a> AgentEngine<'a> {
+    /// Create a new engine.
+    #[must_use]
+    pub fn new(
+        provider: &'a dyn Provider,
+        executor: &'a dyn ToolExecutor,
+        registry: &'a ToolRegistry,
+        tool_defs: Vec<ToolDef>,
+        config: RunConfig,
+    ) -> Self {
+        Self {
+            provider,
+            executor,
+            interceptor: ToolInterceptor::new(registry),
+            tool_defs,
+            config,
+        }
+    }
+
+    /// Run the agent with the given user message.
+    ///
+    /// # Errors
+    /// Returns `RunError` if the run fails (budget exceeded, provider error, etc.).
+    pub async fn run(&self, user_message: &str) -> Result<RunResult, RunError> {
+        let mut state = RunState {
+            messages: Vec::new(),
+            events: Vec::new(),
+            total_tokens: 0,
+            total_cost_cents: 0,
+            budget: if self.config.budget_cents > 0 {
+                Some(BudgetTracker::new(self.config.budget_cents))
+            } else {
+                None
+            },
+        };
+
+        if let Some(ref prompt) = self.config.system_prompt {
+            state.messages.push(Message::system(prompt));
+        }
+        state.messages.push(Message::user(user_message));
+
+        for _turn in 0..self.config.max_turns {
+            let response = self
+                .provider
+                .chat(&state.messages, &self.tool_defs)
+                .await
+                .map_err(|_| RunError::ProviderError)?;
+
+            let cost = calculate_cost(&response.model, &response.usage);
+            state.total_tokens += response.usage.input_tokens + response.usage.output_tokens;
+            state.total_cost_cents += cost;
+
+            state.events.push(RunEvent::LlmCall {
+                model: response.model.clone(),
+                input_tokens: response.usage.input_tokens,
+                output_tokens: response.usage.output_tokens,
+                cost_cents: cost,
+            });
+
+            self.check_budget(&mut state, cost)?;
+
+            if response.tool_calls.is_empty() {
+                return Ok(Self::finish(state, response.content));
+            }
+
+            state.messages.push(Message::assistant(&response.content));
+            self.process_tool_calls(&mut state, &response.tool_calls).await;
+        }
+
+        Ok(Self::finish(state, "Max turns reached".to_string()))
+    }
+
+    /// Check budget and record the cost. Returns `Err` if exceeded.
+    fn check_budget(&self, state: &mut RunState, cost: u64) -> Result<(), RunError> {
+        if let Some(ref mut tracker) = state.budget {
+            if tracker.record_usage(cost).is_err() {
+                state.events.push(RunEvent::BudgetUpdate {
+                    spent_cents: state.total_cost_cents,
+                    limit_cents: self.config.budget_cents,
+                });
+                return Err(RunError::BudgetExceeded);
+            }
+            state.events.push(RunEvent::BudgetUpdate {
+                spent_cents: tracker.spent_cents(),
+                limit_cents: tracker.limit_cents(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Process all tool calls from an LLM response.
+    async fn process_tool_calls(&self, state: &mut RunState, tool_calls: &[ToolCallRequest]) {
+        for tc_req in tool_calls {
+            let tool_call = ToolCall {
+                namespace: Self::extract_namespace(&tc_req.name),
+                action: Self::extract_action(&tc_req.name),
+                arguments: tc_req.arguments.clone(),
+            };
+
+            let intercept = self.interceptor.intercept(&tool_call);
+
+            match intercept {
+                InterceptResult::Allowed | InterceptResult::CappedAt { .. } => {
+                    self.execute_allowed_tool(state, &tc_req.id, tool_call).await;
+                }
+                InterceptResult::Denied { reason } => {
+                    state.events.push(RunEvent::ToolCallAttempt {
+                        tool: tool_call,
+                        allowed: false,
+                        reason: Some(reason.clone()),
+                    });
+                    state.messages.push(Message::tool(
+                        &tc_req.id,
+                        format!("Permission denied: {reason}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Execute an allowed tool call and record the results.
+    async fn execute_allowed_tool(&self, state: &mut RunState, call_id: &str, tool_call: ToolCall) {
+        state.events.push(RunEvent::ToolCallAttempt {
+            tool: tool_call.clone(),
+            allowed: true,
+            reason: None,
+        });
+
+        match self.executor.execute(&tool_call).await {
+            Ok(output) => {
+                state.messages.push(Message::tool(call_id, &output.output));
+                state.events.push(RunEvent::ToolCallResult {
+                    tool: tool_call,
+                    result: super::ToolResult {
+                        success: output.success,
+                        output: output.output,
+                    },
+                });
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                state.messages.push(Message::tool(call_id, &error_msg));
+                state.events.push(RunEvent::ToolCallResult {
+                    tool: tool_call,
+                    result: super::ToolResult {
+                        success: false,
+                        output: error_msg,
+                    },
+                });
+            }
+        }
+    }
+
+    /// Build the final `RunResult`.
+    fn finish(state: RunState, response: String) -> RunResult {
+        let mut events = state.events;
+        events.push(RunEvent::RunComplete {
+            total_cost_cents: state.total_cost_cents,
+            total_tokens: state.total_tokens,
+        });
+        RunResult {
+            response,
+            trace: RunTrace { events },
+            total_tokens: state.total_tokens,
+            total_cost_cents: state.total_cost_cents,
+        }
+    }
+
+    /// Extract namespace from a tool name like `zendesk.read_ticket`.
+    fn extract_namespace(name: &str) -> String {
+        name.find('.').map_or_else(
+            || name.find('_').map_or_else(|| name.to_string(), |i| name[..i].to_string()),
+            |i| name[..i].to_string(),
+        )
+    }
+
+    /// Extract action from a tool name like `zendesk.read_ticket`.
+    fn extract_action(name: &str) -> String {
+        name.find('.').map_or_else(
+            || name.find('_').map_or_else(|| name.to_string(), |i| name[i + 1..].to_string()),
+            |i| name[i + 1..].to_string(),
+        )
+    }
+}

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -1,0 +1,245 @@
+use serde_json::json;
+
+use super::*;
+use crate::ast::{AgentDef, Capability, Constraint, Span};
+use crate::runtime::executor::MockExecutor;
+use crate::runtime::provider::{ChatResponse, MockProvider, ToolCallRequest, ToolDef, Usage};
+
+fn make_agent(can: Vec<Capability>, cannot: Vec<Capability>, budget_cents: Option<u64>) -> AgentDef {
+    AgentDef {
+        name: "test".to_string(),
+        model: Some("gpt-4o".to_string()),
+        can,
+        cannot,
+        budget: budget_cents.map(|amount| crate::ast::Budget {
+            amount,
+            currency: "$".to_string(),
+            unit: "per run".to_string(),
+            span: Span { start: 0, end: 1 },
+        }),
+        span: Span { start: 0, end: 10 },
+    }
+}
+
+fn cap(ns: &str, action: &str) -> Capability {
+    Capability {
+        namespace: ns.to_string(),
+        action: action.to_string(),
+        constraint: None,
+        span: Span { start: 0, end: 1 },
+    }
+}
+
+fn simple_response(content: &str) -> ChatResponse {
+    ChatResponse {
+        content: content.to_string(),
+        tool_calls: vec![],
+        usage: Usage { input_tokens: 100, output_tokens: 50 },
+        model: "gpt-4o".to_string(),
+    }
+}
+
+fn tool_call_response(tool_name: &str, args: serde_json::Value) -> ChatResponse {
+    ChatResponse {
+        content: String::new(),
+        tool_calls: vec![ToolCallRequest {
+            id: "call_1".to_string(),
+            name: tool_name.to_string(),
+            arguments: args,
+        }],
+        usage: Usage { input_tokens: 100, output_tokens: 50 },
+        model: "gpt-4o".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn simple_response_no_tools() {
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("Hello! How can I help?"));
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    );
+
+    let result = engine.run("Hi").await.expect("should succeed");
+    assert_eq!(result.response, "Hello! How can I help?");
+    assert!(result.total_tokens > 0);
+}
+
+#[tokio::test]
+async fn tool_call_then_response() {
+    let agent = make_agent(vec![cap("zendesk", "read_ticket")], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // First: LLM requests a tool call
+    provider.push_response(tool_call_response("zendesk.read_ticket", json!({"id": 123})));
+    // Second: LLM responds with final answer
+    provider.push_response(simple_response("Ticket #123 is about billing."));
+
+    executor.on_call("zendesk", "read_ticket", r#"{"id": 123, "subject": "Billing issue"}"#);
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![ToolDef {
+            name: "zendesk.read_ticket".to_string(),
+            description: "Read a ticket".to_string(),
+            parameters: json!({}),
+        }],
+        RunConfig::default(),
+    );
+
+    let result = engine.run("What's ticket 123?").await.expect("should succeed");
+    assert_eq!(result.response, "Ticket #123 is about billing.");
+
+    // Should have 2 LLM calls and tool events in trace
+    let llm_calls: Vec<_> = result.trace.events.iter().filter(|e| matches!(e, RunEvent::LlmCall { .. })).collect();
+    assert_eq!(llm_calls.len(), 2);
+}
+
+#[tokio::test]
+async fn denied_tool_sends_error_to_llm() {
+    let agent = make_agent(vec![], vec![cap("zendesk", "delete_ticket")], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // LLM tries to call a denied tool
+    provider.push_response(tool_call_response("zendesk.delete_ticket", json!({})));
+    // LLM responds after getting the denial
+    provider.push_response(simple_response("I can't delete tickets."));
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    );
+
+    let result = engine.run("Delete ticket 123").await.expect("should succeed");
+    assert_eq!(result.response, "I can't delete tickets.");
+
+    // Verify there's a denied tool attempt
+    let denied: Vec<_> = result.trace.events.iter().filter(|e| {
+        matches!(e, RunEvent::ToolCallAttempt { allowed: false, .. })
+    }).collect();
+    assert_eq!(denied.len(), 1);
+}
+
+#[tokio::test]
+async fn budget_exceeded_stops_run() {
+    let agent = make_agent(vec![], vec![], Some(1)); // 1 cent budget
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // Response that will cost more than 1 cent
+    provider.push_response(ChatResponse {
+        content: String::new(),
+        tool_calls: vec![],
+        usage: Usage { input_tokens: 100_000, output_tokens: 50_000 }, // ~75 cents for gpt-4o
+        model: "gpt-4o".to_string(),
+    });
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig {
+            budget_cents: 1,
+            ..RunConfig::default()
+        },
+    );
+
+    let err = engine.run("Hi").await.unwrap_err();
+    assert!(matches!(err, RunError::BudgetExceeded));
+}
+
+#[tokio::test]
+async fn max_turns_respected() {
+    let agent = make_agent(vec![cap("zendesk", "read_ticket")], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // Keep requesting tool calls to exhaust turns
+    for _ in 0..3 {
+        provider.push_response(tool_call_response("zendesk.read_ticket", json!({})));
+    }
+    executor.on_call("zendesk", "read_ticket", "data");
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig {
+            max_turns: 3,
+            ..RunConfig::default()
+        },
+    );
+
+    let result = engine.run("loop").await.expect("should not error");
+    assert_eq!(result.response, "Max turns reached");
+}
+
+#[tokio::test]
+async fn system_prompt_included() {
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("I am a support agent."));
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig {
+            system_prompt: Some("You are a support agent.".to_string()),
+            ..RunConfig::default()
+        },
+    );
+
+    let result = engine.run("Who are you?").await.expect("should succeed");
+    assert_eq!(result.response, "I am a support agent.");
+}
+
+#[tokio::test]
+async fn trace_contains_run_complete() {
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("Done"));
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    );
+
+    let result = engine.run("test").await.expect("ok");
+    let complete: Vec<_> = result.trace.events.iter().filter(|e| {
+        matches!(e, RunEvent::RunComplete { .. })
+    }).collect();
+    assert_eq!(complete.len(), 1);
+}

--- a/src/runtime/executor/mod.rs
+++ b/src/runtime/executor/mod.rs
@@ -1,0 +1,103 @@
+use super::ToolCall;
+
+#[cfg(test)]
+mod tests;
+
+/// The result of executing a tool.
+#[derive(Debug, Clone)]
+pub struct ToolOutput {
+    pub success: bool,
+    pub output: String,
+}
+
+/// Errors from tool execution.
+#[derive(Debug)]
+pub enum ExecutorError {
+    /// The tool is not registered or available.
+    NotFound(String),
+    /// The tool execution failed.
+    Failed(String),
+}
+
+impl std::fmt::Display for ExecutorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(name) => write!(f, "tool not found: {name}"),
+            Self::Failed(msg) => write!(f, "tool execution failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ExecutorError {}
+
+/// Executes tool calls. Implementations can be mock (for testing) or real
+/// (for production use with actual APIs).
+#[async_trait::async_trait]
+pub trait ToolExecutor: Send + Sync {
+    /// Execute a tool call and return its output.
+    async fn execute(&self, tool_call: &ToolCall) -> Result<ToolOutput, ExecutorError>;
+}
+
+// ---------------------------------------------------------------------------
+// Mock executor
+// ---------------------------------------------------------------------------
+
+/// A mock executor that returns pre-configured responses for specific tools.
+#[derive(Debug, Default)]
+pub struct MockExecutor {
+    handlers: std::sync::Mutex<Vec<MockHandler>>,
+}
+
+#[derive(Debug)]
+struct MockHandler {
+    namespace: String,
+    action: String,
+    response: Result<ToolOutput, String>,
+}
+
+impl MockExecutor {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a successful response for a tool.
+    pub fn on_call(&self, namespace: &str, action: &str, output: impl Into<String>) {
+        self.handlers.lock().expect("lock poisoned").push(MockHandler {
+            namespace: namespace.to_string(),
+            action: action.to_string(),
+            response: Ok(ToolOutput {
+                success: true,
+                output: output.into(),
+            }),
+        });
+    }
+
+    /// Register a failure response for a tool.
+    pub fn on_call_fail(&self, namespace: &str, action: &str, error: impl Into<String>) {
+        self.handlers.lock().expect("lock poisoned").push(MockHandler {
+            namespace: namespace.to_string(),
+            action: action.to_string(),
+            response: Err(error.into()),
+        });
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for MockExecutor {
+    async fn execute(&self, tool_call: &ToolCall) -> Result<ToolOutput, ExecutorError> {
+        let handlers = self.handlers.lock().expect("lock poisoned");
+        for handler in handlers.iter() {
+            if handler.namespace == tool_call.namespace && handler.action == tool_call.action {
+                return match &handler.response {
+                    Ok(output) => Ok(output.clone()),
+                    Err(msg) => Err(ExecutorError::Failed(msg.clone())),
+                };
+            }
+        }
+        Err(ExecutorError::NotFound(format!(
+            "{}.{}",
+            tool_call.namespace, tool_call.action
+        )))
+    }
+}

--- a/src/runtime/executor/tests.rs
+++ b/src/runtime/executor/tests.rs
@@ -1,0 +1,49 @@
+use serde_json::json;
+
+use super::*;
+
+fn tool_call(ns: &str, action: &str) -> ToolCall {
+    ToolCall {
+        namespace: ns.to_string(),
+        action: action.to_string(),
+        arguments: json!({}),
+    }
+}
+
+#[tokio::test]
+async fn mock_returns_registered_response() {
+    let executor = MockExecutor::new();
+    executor.on_call("zendesk", "read_ticket", r#"{"id": 123, "subject": "Help"}"#);
+
+    let result = executor.execute(&tool_call("zendesk", "read_ticket")).await.expect("should work");
+    assert!(result.success);
+    assert!(result.output.contains("123"));
+}
+
+#[tokio::test]
+async fn mock_returns_failure() {
+    let executor = MockExecutor::new();
+    executor.on_call_fail("zendesk", "refund", "insufficient funds");
+
+    let err = executor.execute(&tool_call("zendesk", "refund")).await.unwrap_err();
+    assert!(err.to_string().contains("insufficient funds"));
+}
+
+#[tokio::test]
+async fn mock_unknown_tool_returns_not_found() {
+    let executor = MockExecutor::new();
+    let err = executor.execute(&tool_call("stripe", "charge")).await.unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[tokio::test]
+async fn mock_multiple_tools() {
+    let executor = MockExecutor::new();
+    executor.on_call("zendesk", "read_ticket", "ticket data");
+    executor.on_call("zendesk", "reply_ticket", "reply sent");
+
+    let r1 = executor.execute(&tool_call("zendesk", "read_ticket")).await.expect("ok");
+    let r2 = executor.execute(&tool_call("zendesk", "reply_ticket")).await.expect("ok");
+    assert!(r1.output.contains("ticket"));
+    assert!(r2.output.contains("reply"));
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,6 @@
 pub mod budget;
+pub mod engine;
+pub mod executor;
 pub mod interceptor;
 pub mod permissions;
 pub mod provider;


### PR DESCRIPTION
The core of rein run. AgentEngine orchestrates the LLM → tool call → result loop with permission enforcement, budget tracking, and run tracing. MockExecutor for testing. 11 new tests (184 total). Closes #49, #50