### PR TITLE
feat: run trace output. Closes #51

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -57,6 +57,56 @@ pub struct RunTrace {
     pub events: Vec<RunEvent>,
 }
 
+impl RunTrace {
+    /// Serialize to pretty-printed JSON.
+    ///
+    /// # Errors
+    /// Returns a serialization error if the trace cannot be serialized.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Produce a compact human-readable summary.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let mut lines = Vec::new();
+        let mut turn = 0_usize;
+
+        for event in &self.events {
+            match event {
+                RunEvent::LlmCall { model, input_tokens, output_tokens, cost_cents } => {
+                    turn += 1;
+                    lines.push(format!(
+                        "[turn {turn}] LLM call ({model}): {input_tokens} in / {output_tokens} out, {cost_cents}¢"
+                    ));
+                }
+                RunEvent::ToolCallAttempt { tool, allowed, reason } => {
+                    let status = if *allowed { "✓" } else { "✗" };
+                    let tool_name = format!("{}.{}", tool.namespace, tool.action);
+                    let suffix = reason.as_ref().map_or(String::new(), |r| format!(" ({r})"));
+                    lines.push(format!("  {status} tool: {tool_name}{suffix}"));
+                }
+                RunEvent::ToolCallResult { tool, result } => {
+                    let status = if result.success { "ok" } else { "err" };
+                    let tool_name = format!("{}.{}", tool.namespace, tool.action);
+                    let preview: String = result.output.chars().take(80).collect();
+                    lines.push(format!("  → {tool_name} [{status}]: {preview}"));
+                }
+                RunEvent::BudgetUpdate { spent_cents, limit_cents } => {
+                    lines.push(format!("  budget: {spent_cents}¢ / {limit_cents}¢"));
+                }
+                RunEvent::RunComplete { total_cost_cents, total_tokens } => {
+                    lines.push(format!(
+                        "Done. {total_tokens} tokens, {total_cost_cents}¢ total."
+                    ));
+                }
+            }
+        }
+
+        lines.join("\n")
+    }
+}
+
 /// Errors that can occur during an agent run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -496,3 +496,106 @@ fn run_error_serializes_as_snake_case() {
     let v: serde_json::Value = serde_json::to_value(RunError::ConfigError).expect("serialize");
     assert_eq!(v, "config_error");
 }
+
+// ── RunTrace output ────────────────────────────────────────────────────────
+
+#[test]
+fn trace_to_json_produces_valid_json() {
+    let trace = RunTrace {
+        events: vec![
+            RunEvent::LlmCall {
+                model: "gpt-4o".into(),
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_cents: 1,
+            },
+            RunEvent::RunComplete {
+                total_cost_cents: 1,
+                total_tokens: 150,
+            },
+        ],
+    };
+    let json = trace.to_json().expect("should serialize");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert!(parsed["events"].is_array());
+    assert_eq!(parsed["events"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn trace_summary_contains_turns() {
+    let trace = RunTrace {
+        events: vec![
+            RunEvent::LlmCall {
+                model: "gpt-4o".into(),
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_cents: 1,
+            },
+            RunEvent::ToolCallAttempt {
+                tool: ToolCall {
+                    namespace: "zendesk".into(),
+                    action: "read_ticket".into(),
+                    arguments: serde_json::Value::Null,
+                },
+                allowed: true,
+                reason: None,
+            },
+            RunEvent::ToolCallResult {
+                tool: ToolCall {
+                    namespace: "zendesk".into(),
+                    action: "read_ticket".into(),
+                    arguments: serde_json::Value::Null,
+                },
+                result: ToolResult {
+                    success: true,
+                    output: "ticket data".into(),
+                },
+            },
+            RunEvent::RunComplete {
+                total_cost_cents: 1,
+                total_tokens: 150,
+            },
+        ],
+    };
+    let summary = trace.summary();
+    assert!(summary.contains("turn 1"), "summary: {summary}");
+    assert!(summary.contains("zendesk.read_ticket"), "summary: {summary}");
+    assert!(summary.contains("Done"), "summary: {summary}");
+}
+
+#[test]
+fn trace_summary_shows_denied_tools() {
+    let trace = RunTrace {
+        events: vec![
+            RunEvent::LlmCall {
+                model: "gpt-4o".into(),
+                input_tokens: 50,
+                output_tokens: 25,
+                cost_cents: 1,
+            },
+            RunEvent::ToolCallAttempt {
+                tool: ToolCall {
+                    namespace: "stripe".into(),
+                    action: "charge".into(),
+                    arguments: serde_json::Value::Null,
+                },
+                allowed: false,
+                reason: Some("not in can list".into()),
+            },
+            RunEvent::RunComplete {
+                total_cost_cents: 1,
+                total_tokens: 75,
+            },
+        ],
+    };
+    let summary = trace.summary();
+    assert!(summary.contains("✗"), "should show denied marker");
+    assert!(summary.contains("not in can list"), "summary: {summary}");
+}
+
+#[test]
+fn trace_summary_empty_trace() {
+    let trace = RunTrace { events: vec![] };
+    let summary = trace.summary();
+    assert!(summary.is_empty());
+}


### PR DESCRIPTION
RunTrace.to_json() and RunTrace.summary() methods. 4 new tests. Closes #51