### PR TITLE
feat: workflow parser. Closes #73

### DIFF
--- a/examples/workflow.rein
+++ b/examples/workflow.rein
@@ -1,0 +1,34 @@
+// A support pipeline workflow with three stages.
+
+agent triage {
+    model: openai
+    can [
+        zendesk.read_ticket
+        zendesk.classify_ticket
+    ]
+    cannot [
+        zendesk.delete_ticket
+    ]
+}
+
+agent responder {
+    model: openai
+    can [
+        zendesk.read_ticket
+        zendesk.reply_ticket
+    ]
+}
+
+agent escalator {
+    model: anthropic
+    can [
+        zendesk.read_ticket
+        zendesk.escalate_ticket
+        slack.send_message
+    ]
+}
+
+workflow support_pipeline {
+    trigger: incoming_ticket
+    stages: [triage, responder, escalator]
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -12,6 +12,9 @@ pub enum TokenKind {
     Per,
     Up,
     To,
+    Workflow,
+    Trigger,
+    Stages,
     // Symbols
     LBrace,
     RBrace,
@@ -19,6 +22,7 @@ pub enum TokenKind {
     RBracket,
     Colon,
     Dot,
+    Comma,
     // Literals
     Ident(String),
     StringLiteral(String),
@@ -37,6 +41,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::RBracket => write!(f, "]"),
             TokenKind::Colon => write!(f, ":"),
             TokenKind::Dot => write!(f, "."),
+            TokenKind::Comma => write!(f, ","),
             TokenKind::Agent => write!(f, "agent"),
             TokenKind::Can => write!(f, "can"),
             TokenKind::Cannot => write!(f, "cannot"),
@@ -45,6 +50,9 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Per => write!(f, "per"),
             TokenKind::Up => write!(f, "up"),
             TokenKind::To => write!(f, "to"),
+            TokenKind::Workflow => write!(f, "workflow"),
+            TokenKind::Trigger => write!(f, "trigger"),
+            TokenKind::Stages => write!(f, "stages"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Dollar(n) => write!(f, "${}.{:02}", n / 100, n % 100),
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
@@ -156,6 +164,9 @@ impl<'a> Lexer<'a> {
             "per" => TokenKind::Per,
             "up" => TokenKind::Up,
             "to" => TokenKind::To,
+            "workflow" => TokenKind::Workflow,
+            "trigger" => TokenKind::Trigger,
+            "stages" => TokenKind::Stages,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)
@@ -304,6 +315,7 @@ impl<'a> Lexer<'a> {
                 Some(b']') => tokens.push(Token::new(TokenKind::RBracket, start, self.pos)),
                 Some(b':') => tokens.push(Token::new(TokenKind::Colon, start, self.pos)),
                 Some(b'.') => tokens.push(Token::new(TokenKind::Dot, start, self.pos)),
+                Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
                 Some(b'"') => tokens.push(self.read_string(start)?),
                 Some(b'$') => tokens.push(self.read_dollar(start)?),
                 Some(b'/') if self.peek() == Some(b'/') => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,7 @@
-use crate::ast::{AgentDef, Budget, Capability, Constraint, ReinFile, Span};
+use crate::ast::{
+    AgentDef, Budget, Capability, Constraint, ExecutionMode, ReinFile, RouteRule, Span, Stage,
+    WorkflowDef,
+};
 use crate::lexer::{Token, TokenKind, tokenize};
 
 /// Parse error with source location and message.
@@ -142,11 +145,21 @@ impl Parser {
     pub fn parse_file(&mut self) -> Result<ReinFile, ParseError> {
         self.skip_comments();
         let mut agents = Vec::new();
+        let mut workflows = Vec::new();
         while self.peek() != &TokenKind::Eof {
-            agents.push(self.parse_agent()?);
+            match self.peek() {
+                TokenKind::Agent => agents.push(self.parse_agent()?),
+                TokenKind::Workflow => workflows.push(self.parse_workflow()?),
+                other => {
+                    return Err(ParseError::new(
+                        format!("expected 'agent' or 'workflow', got {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
             self.skip_comments();
         }
-        Ok(ReinFile { agents, workflows: Vec::new() })
+        Ok(ReinFile { agents, workflows })
     }
 
     fn parse_agent(&mut self) -> Result<AgentDef, ParseError> {
@@ -250,6 +263,127 @@ impl Parser {
                 }
             }
         }
+    }
+
+    fn parse_workflow(&mut self) -> Result<WorkflowDef, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Workflow)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut trigger: Option<String> = None;
+        let mut stages: Vec<Stage> = Vec::new();
+        let mut seen_trigger = false;
+        let mut seen_stages = false;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+
+                    let trigger = trigger.ok_or_else(|| {
+                        ParseError::new(
+                            format!("workflow '{name}' is missing required field 'trigger'"),
+                            Span::new(start, end),
+                        )
+                    })?;
+
+                    if stages.is_empty() {
+                        return Err(ParseError::new(
+                            format!("workflow '{name}' must have at least one stage"),
+                            Span::new(start, end),
+                        ));
+                    }
+
+                    return Ok(WorkflowDef {
+                        name,
+                        trigger,
+                        stages,
+                        mode: ExecutionMode::Sequential,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Trigger => {
+                    if seen_trigger {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'trigger' in workflow '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_trigger = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    let (value, _) = self.expect_ident()?;
+                    trigger = Some(value);
+                }
+                TokenKind::Stages => {
+                    if seen_stages {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'stages' in workflow '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_stages = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    stages = self.parse_stage_list()?;
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file: expected `}`",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected token in workflow body: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn parse_stage_list(&mut self) -> Result<Vec<Stage>, ParseError> {
+        self.expect(&TokenKind::LBracket)?;
+        let mut stages = Vec::new();
+        loop {
+            self.skip_comments();
+            match self.peek() {
+                TokenKind::RBracket => {
+                    self.advance();
+                    break;
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file: expected `]`",
+                        self.current_span(),
+                    ));
+                }
+                _ => {
+                    let stage_start = self.current_span().start;
+                    let (agent_name, _) = self.expect_ident()?;
+                    let end = self.last_consumed_end;
+
+                    stages.push(Stage {
+                        name: agent_name.clone(),
+                        agent: agent_name,
+                        route: RouteRule::Next,
+                        span: Span::new(stage_start, end),
+                    });
+
+                    // Optional comma separator
+                    if self.peek() == &TokenKind::Comma {
+                        self.advance();
+                    }
+                }
+            }
+        }
+        Ok(stages)
     }
 
     fn parse_capability_list(&mut self) -> Result<Vec<Capability>, ParseError> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -281,3 +281,111 @@ fn error_budget_missing_dollar() {
         err.message
     );
 }
+
+// ── Workflow parsing ──────────────────────────────────────────────────────
+
+#[test]
+fn parse_simple_workflow() {
+    let file = parse_ok(r#"
+        agent triage { model: openai can [ zendesk.read_ticket ] }
+        workflow pipeline {
+            trigger: incoming_ticket
+            stages: [triage]
+        }
+    "#);
+    assert_eq!(file.workflows.len(), 1);
+    let wf = &file.workflows[0];
+    assert_eq!(wf.name, "pipeline");
+    assert_eq!(wf.trigger, "incoming_ticket");
+    assert_eq!(wf.stages.len(), 1);
+    assert_eq!(wf.stages[0].agent, "triage");
+}
+
+#[test]
+fn parse_workflow_multiple_stages() {
+    let file = parse_ok(r#"
+        agent a { model: openai }
+        agent b { model: openai }
+        agent c { model: openai }
+        workflow pipe {
+            trigger: event
+            stages: [a, b, c]
+        }
+    "#);
+    assert_eq!(file.workflows[0].stages.len(), 3);
+    assert_eq!(file.workflows[0].stages[0].agent, "a");
+    assert_eq!(file.workflows[0].stages[1].agent, "b");
+    assert_eq!(file.workflows[0].stages[2].agent, "c");
+}
+
+#[test]
+fn parse_workflow_stages_without_commas() {
+    let file = parse_ok(r#"
+        agent a { model: openai }
+        agent b { model: openai }
+        workflow pipe {
+            trigger: event
+            stages: [a b]
+        }
+    "#);
+    assert_eq!(file.workflows[0].stages.len(), 2);
+}
+
+#[test]
+fn parse_workflow_missing_trigger_errors() {
+    let err = parse_err(r#"
+        workflow pipe {
+            stages: [a]
+        }
+    "#);
+    assert!(err.message.contains("trigger"), "err: {}", err.message);
+}
+
+#[test]
+fn parse_workflow_empty_stages_errors() {
+    let err = parse_err(r#"
+        workflow pipe {
+            trigger: event
+            stages: []
+        }
+    "#);
+    assert!(err.message.contains("at least one stage"), "err: {}", err.message);
+}
+
+#[test]
+fn parse_workflow_duplicate_trigger_errors() {
+    let err = parse_err(r#"
+        workflow pipe {
+            trigger: a
+            trigger: b
+            stages: [x]
+        }
+    "#);
+    assert!(err.message.contains("duplicate"), "err: {}", err.message);
+}
+
+#[test]
+fn parse_file_with_agents_and_workflows() {
+    let file = parse_ok(r#"
+        agent triage { model: openai can [ zendesk.read_ticket ] }
+        agent responder { model: anthropic can [ zendesk.reply_ticket ] }
+        workflow pipeline {
+            trigger: ticket
+            stages: [triage, responder]
+        }
+    "#);
+    assert_eq!(file.agents.len(), 2);
+    assert_eq!(file.workflows.len(), 1);
+}
+
+#[test]
+fn parse_multiple_workflows() {
+    let file = parse_ok(r#"
+        agent a { model: openai }
+        workflow w1 { trigger: e1 stages: [a] }
+        workflow w2 { trigger: e2 stages: [a] }
+    "#);
+    assert_eq!(file.workflows.len(), 2);
+    assert_eq!(file.workflows[0].name, "w1");
+    assert_eq!(file.workflows[1].name, "w2");
+}


### PR DESCRIPTION
Extends lexer with workflow/trigger/stages/comma tokens. Parser handles workflow blocks with trigger and stage list. 8 new parser tests, workflow example file. 224 total tests. Closes #73