### PR TITLE
feat: sequential workflow executor. Closes #76

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@ pub mod executor;
 pub mod interceptor;
 pub mod permissions;
 pub mod provider;
+pub mod workflow;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -1,0 +1,119 @@
+use crate::ast::{ReinFile, WorkflowDef};
+
+use super::engine::{AgentEngine, RunConfig};
+use super::executor::ToolExecutor;
+use super::permissions::ToolRegistry;
+use super::provider::{Provider, ToolDef};
+
+#[cfg(test)]
+mod tests;
+
+/// The result of a completed workflow run.
+#[derive(Debug)]
+pub struct WorkflowResult {
+    /// Results from each stage, in order.
+    pub stage_results: Vec<StageResult>,
+    /// The final output text (from the last stage).
+    pub final_output: String,
+    /// Total cost across all stages.
+    pub total_cost_cents: u64,
+    /// Total tokens across all stages.
+    pub total_tokens: u64,
+}
+
+/// The result of a single stage within a workflow.
+#[derive(Debug)]
+pub struct StageResult {
+    pub stage_name: String,
+    pub agent_name: String,
+    pub output: String,
+    pub cost_cents: u64,
+    pub tokens: u64,
+}
+
+/// Errors that can occur during workflow execution.
+#[derive(Debug)]
+pub enum WorkflowError {
+    /// A stage's agent was not found in the file.
+    AgentNotFound(String),
+    /// A stage failed during execution.
+    StageFailed {
+        stage: String,
+        error: super::RunError,
+    },
+}
+
+impl std::fmt::Display for WorkflowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AgentNotFound(name) => write!(f, "agent not found: {name}"),
+            Self::StageFailed { stage, error } => {
+                write!(f, "stage '{stage}' failed: {error:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WorkflowError {}
+
+/// Execute a workflow sequentially: each stage's output becomes the next stage's input.
+///
+/// # Errors
+/// Returns `WorkflowError` if an agent is missing or a stage fails.
+pub async fn run_sequential(
+    workflow: &WorkflowDef,
+    file: &ReinFile,
+    provider: &dyn Provider,
+    executor: &dyn ToolExecutor,
+    tool_defs: &[ToolDef],
+    config: &RunConfig,
+) -> Result<WorkflowResult, WorkflowError> {
+    let mut stage_results = Vec::new();
+    let mut current_input = format!("Trigger: {}", workflow.trigger);
+    let mut total_cost: u64 = 0;
+    let mut total_tokens: u64 = 0;
+
+    for stage in &workflow.stages {
+        let agent = file
+            .agents
+            .iter()
+            .find(|a| a.name == stage.agent)
+            .ok_or_else(|| WorkflowError::AgentNotFound(stage.agent.clone()))?;
+
+        let registry = ToolRegistry::from_agent(agent);
+
+        let engine = AgentEngine::new(provider, executor, &registry, tool_defs.to_vec(), config.clone());
+
+        let result = engine
+            .run(&current_input)
+            .await
+            .map_err(|e| WorkflowError::StageFailed {
+                stage: stage.name.clone(),
+                error: e,
+            })?;
+
+        current_input.clone_from(&result.response);
+        total_cost += result.total_cost_cents;
+        total_tokens += result.total_tokens;
+
+        stage_results.push(StageResult {
+            stage_name: stage.name.clone(),
+            agent_name: stage.agent.clone(),
+            output: result.response,
+            cost_cents: result.total_cost_cents,
+            tokens: result.total_tokens,
+        });
+    }
+
+    let final_output = stage_results
+        .last()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+
+    Ok(WorkflowResult {
+        stage_results,
+        final_output,
+        total_cost_cents: total_cost,
+        total_tokens,
+    })
+}

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::ast::{ExecutionMode, RouteRule, Span, Stage};
+use crate::runtime::executor::MockExecutor;
+use crate::runtime::provider::{ChatResponse, MockProvider, Usage};
+
+fn simple_response(content: &str) -> ChatResponse {
+    ChatResponse {
+        content: content.to_string(),
+        tool_calls: vec![],
+        usage: Usage { input_tokens: 100, output_tokens: 50 },
+        model: "gpt-4o".to_string(),
+    }
+}
+
+fn parse_file(src: &str) -> ReinFile {
+    crate::parser::parse(src).expect("parse should succeed")
+}
+
+fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDef {
+    WorkflowDef {
+        name: name.to_string(),
+        trigger: trigger.to_string(),
+        stages: stage_agents
+            .iter()
+            .map(|a| Stage {
+                name: (*a).to_string(),
+                agent: (*a).to_string(),
+                route: RouteRule::Next,
+                span: Span::new(0, 1),
+            })
+            .collect(),
+        mode: ExecutionMode::Sequential,
+        span: Span::new(0, 1),
+    }
+}
+
+#[tokio::test]
+async fn single_stage_workflow() {
+    let file = parse_file(r#"
+        agent triage { model: openai can [ zendesk.read_ticket ] }
+    "#);
+    let workflow = make_workflow("pipe", "ticket", &["triage"]);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("Triaged: low priority"));
+
+    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.stage_results.len(), 1);
+    assert_eq!(result.final_output, "Triaged: low priority");
+    assert!(result.total_tokens > 0);
+}
+
+#[tokio::test]
+async fn two_stage_pipeline_passes_output() {
+    let file = parse_file(r#"
+        agent triage { model: openai }
+        agent responder { model: openai }
+    "#);
+    let workflow = make_workflow("pipe", "ticket", &["triage", "responder"]);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // Stage 1: triage
+    provider.push_response(simple_response("Priority: high. Issue: billing error."));
+    // Stage 2: responder (receives triage output as input)
+    provider.push_response(simple_response("Dear customer, we've fixed your billing issue."));
+
+    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.stage_results.len(), 2);
+    assert_eq!(result.stage_results[0].output, "Priority: high. Issue: billing error.");
+    assert_eq!(result.final_output, "Dear customer, we've fixed your billing issue.");
+    assert_eq!(result.total_cost_cents, result.stage_results[0].cost_cents + result.stage_results[1].cost_cents);
+}
+
+#[tokio::test]
+async fn three_stage_pipeline() {
+    let file = parse_file(r#"
+        agent a { model: openai }
+        agent b { model: openai }
+        agent c { model: openai }
+    "#);
+    let workflow = make_workflow("pipe", "event", &["a", "b", "c"]);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("output_a"));
+    provider.push_response(simple_response("output_b"));
+    provider.push_response(simple_response("output_c"));
+
+    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.stage_results.len(), 3);
+    assert_eq!(result.final_output, "output_c");
+}
+
+#[tokio::test]
+async fn unknown_agent_returns_error() {
+    let file = parse_file("agent a { model: openai }");
+    let workflow = make_workflow("pipe", "event", &["a", "nonexistent"]);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("ok"));
+
+    let err = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("nonexistent"), "err: {err}");
+}
+
+#[tokio::test]
+async fn stage_failure_returns_error() {
+    let file = parse_file("agent a { model: openai }");
+    let workflow = make_workflow("pipe", "event", &["a"]);
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_error("provider down");
+
+    let err = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, WorkflowError::StageFailed { .. }));
+}


### PR DESCRIPTION
Executes workflow stages sequentially, passing each agent's output as the next stage's input. 5 tests covering: single/multi-stage, error handling. Closes #76