### PR TITLE
feat: conditional workflow routing. Closes #77

### DIFF
--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::{ExecutionMode, ReinFile, WorkflowDef};
+use crate::ast::{ExecutionMode, ReinFile, RouteRule, Stage, WorkflowDef};
 
 use super::engine::{AgentEngine, RunConfig};
 use super::executor::ToolExecutor;
@@ -41,6 +41,8 @@ pub enum WorkflowError {
         stage: String,
         error: super::RunError,
     },
+    /// A route references a stage that doesn't exist.
+    StageNotFound(String),
 }
 
 impl std::fmt::Display for WorkflowError {
@@ -50,6 +52,7 @@ impl std::fmt::Display for WorkflowError {
             Self::StageFailed { stage, error } => {
                 write!(f, "stage '{stage}' failed: {error:?}")
             }
+            Self::StageNotFound(name) => write!(f, "route target stage not found: {name}"),
         }
     }
 }
@@ -75,7 +78,13 @@ async fn run_stage(
         .ok_or_else(|| WorkflowError::AgentNotFound(agent_name.to_string()))?;
 
     let registry = ToolRegistry::from_agent(agent);
-    let engine = AgentEngine::new(provider, executor, &registry, tool_defs.to_vec(), config.clone());
+    let engine = AgentEngine::new(
+        provider,
+        executor,
+        &registry,
+        tool_defs.to_vec(),
+        config.clone(),
+    );
 
     let result = engine
         .run(input)
@@ -106,10 +115,47 @@ fn build_result(stage_results: Vec<StageResult>, final_output: String) -> Workfl
     }
 }
 
-/// Execute a workflow sequentially: each stage's output becomes the next stage's input.
+/// Check whether a conditional route matches the agent output.
+///
+/// Looks for `field: value` or `field=value` patterns in the output text.
+fn condition_matches(output: &str, field: &str, equals: &str) -> bool {
+    let lower = output.to_lowercase();
+    let field_lower = field.to_lowercase();
+    let equals_lower = equals.to_lowercase();
+
+    for line in lower.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(&field_lower) {
+            let rest = rest.trim_start();
+            if rest
+                .strip_prefix(':')
+                .is_some_and(|val| val.trim().starts_with(&equals_lower))
+            {
+                return true;
+            }
+            if rest
+                .strip_prefix('=')
+                .is_some_and(|val| val.trim().starts_with(&equals_lower))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Find a stage by name within a workflow.
+fn find_stage<'a>(workflow: &'a WorkflowDef, name: &str) -> Option<&'a Stage> {
+    workflow.stages.iter().find(|s| s.name == name)
+}
+
+/// Execute a workflow sequentially: each stage's output becomes the next
+/// stage's input. Respects [`RouteRule::Conditional`] for branching to named
+/// stages.
 ///
 /// # Errors
-/// Returns `WorkflowError` if an agent is missing or a stage fails.
+/// Returns `WorkflowError` if an agent is missing, a stage fails, or a route
+/// references a nonexistent stage.
 pub async fn run_sequential(
     workflow: &WorkflowDef,
     file: &ReinFile,
@@ -120,15 +166,57 @@ pub async fn run_sequential(
 ) -> Result<WorkflowResult, WorkflowError> {
     let mut stage_results = Vec::new();
     let mut current_input = format!("Trigger: {}", workflow.trigger);
+    let mut visited = std::collections::HashSet::new();
 
-    for stage in &workflow.stages {
+    let mut current_stage: Option<&Stage> = workflow.stages.first();
+
+    while let Some(stage) = current_stage {
+        if !visited.insert(stage.name.clone()) {
+            break; // circular routing protection
+        }
+
         let result = run_stage(
-            &stage.name, &stage.agent, &current_input,
-            file, provider, executor, tool_defs, config,
-        ).await?;
+            &stage.name,
+            &stage.agent,
+            &current_input,
+            file,
+            provider,
+            executor,
+            tool_defs,
+            config,
+        )
+        .await?;
 
         current_input.clone_from(&result.output);
+        let output = result.output.clone();
         stage_results.push(result);
+
+        current_stage = match &stage.route {
+            RouteRule::Next => {
+                let idx = workflow.stages.iter().position(|s| s.name == stage.name);
+                idx.and_then(|i| workflow.stages.get(i + 1))
+            }
+            RouteRule::Conditional {
+                field,
+                equals,
+                then_stage,
+                else_stage,
+            } => {
+                if condition_matches(&output, field, equals) {
+                    Some(
+                        find_stage(workflow, then_stage)
+                            .ok_or_else(|| WorkflowError::StageNotFound(then_stage.clone()))?,
+                    )
+                } else if let Some(else_name) = else_stage {
+                    Some(
+                        find_stage(workflow, else_name)
+                            .ok_or_else(|| WorkflowError::StageNotFound(else_name.clone()))?,
+                    )
+                } else {
+                    None
+                }
+            }
+        };
     }
 
     let final_output = stage_results
@@ -158,9 +246,16 @@ pub async fn run_parallel(
     // Fan-out: each stage gets the trigger input (not chained)
     for stage in &workflow.stages {
         let result = run_stage(
-            &stage.name, &stage.agent, &trigger_input,
-            file, provider, executor, tool_defs, config,
-        ).await?;
+            &stage.name,
+            &stage.agent,
+            &trigger_input,
+            file,
+            provider,
+            executor,
+            tool_defs,
+            config,
+        )
+        .await?;
         stage_results.push(result);
     }
 

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ast::{ExecutionMode, RouteRule, Span, Stage};
+use crate::ast::{ExecutionMode, RouteRule, Span, Stage, WorkflowDef};
 use crate::runtime::executor::MockExecutor;
 use crate::runtime::provider::{ChatResponse, MockProvider, Usage};
 
@@ -7,7 +7,10 @@ fn simple_response(content: &str) -> ChatResponse {
     ChatResponse {
         content: content.to_string(),
         tool_calls: vec![],
-        usage: Usage { input_tokens: 100, output_tokens: 50 },
+        usage: Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+        },
         model: "gpt-4o".to_string(),
     }
 }
@@ -36,18 +39,27 @@ fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDe
 
 #[tokio::test]
 async fn single_stage_workflow() {
-    let file = parse_file(r#"
+    let file = parse_file(
+        r"
         agent triage { model: openai can [ zendesk.read_ticket ] }
-    "#);
+    ",
+    );
     let workflow = make_workflow("pipe", "ticket", &["triage"]);
     let provider = MockProvider::new();
     let executor = MockExecutor::new();
 
     provider.push_response(simple_response("Triaged: low priority"));
 
-    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("should succeed");
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("should succeed");
 
     assert_eq!(result.stage_results.len(), 1);
     assert_eq!(result.final_output, "Triaged: low priority");
@@ -56,10 +68,12 @@ async fn single_stage_workflow() {
 
 #[tokio::test]
 async fn two_stage_pipeline_passes_output() {
-    let file = parse_file(r#"
+    let file = parse_file(
+        r"
         agent triage { model: openai }
         agent responder { model: openai }
-    "#);
+    ",
+    );
     let workflow = make_workflow("pipe", "ticket", &["triage", "responder"]);
     let provider = MockProvider::new();
     let executor = MockExecutor::new();
@@ -67,25 +81,45 @@ async fn two_stage_pipeline_passes_output() {
     // Stage 1: triage
     provider.push_response(simple_response("Priority: high. Issue: billing error."));
     // Stage 2: responder (receives triage output as input)
-    provider.push_response(simple_response("Dear customer, we've fixed your billing issue."));
+    provider.push_response(simple_response(
+        "Dear customer, we've fixed your billing issue.",
+    ));
 
-    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("should succeed");
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("should succeed");
 
     assert_eq!(result.stage_results.len(), 2);
-    assert_eq!(result.stage_results[0].output, "Priority: high. Issue: billing error.");
-    assert_eq!(result.final_output, "Dear customer, we've fixed your billing issue.");
-    assert_eq!(result.total_cost_cents, result.stage_results[0].cost_cents + result.stage_results[1].cost_cents);
+    assert_eq!(
+        result.stage_results[0].output,
+        "Priority: high. Issue: billing error."
+    );
+    assert_eq!(
+        result.final_output,
+        "Dear customer, we've fixed your billing issue."
+    );
+    assert_eq!(
+        result.total_cost_cents,
+        result.stage_results[0].cost_cents + result.stage_results[1].cost_cents
+    );
 }
 
 #[tokio::test]
 async fn three_stage_pipeline() {
-    let file = parse_file(r#"
+    let file = parse_file(
+        r"
         agent a { model: openai }
         agent b { model: openai }
         agent c { model: openai }
-    "#);
+    ",
+    );
     let workflow = make_workflow("pipe", "event", &["a", "b", "c"]);
     let provider = MockProvider::new();
     let executor = MockExecutor::new();
@@ -94,9 +128,16 @@ async fn three_stage_pipeline() {
     provider.push_response(simple_response("output_b"));
     provider.push_response(simple_response("output_c"));
 
-    let result = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("should succeed");
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("should succeed");
 
     assert_eq!(result.stage_results.len(), 3);
     assert_eq!(result.final_output, "output_c");
@@ -111,9 +152,16 @@ async fn unknown_agent_returns_error() {
 
     provider.push_response(simple_response("ok"));
 
-    let err = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .unwrap_err();
+    let err = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(err.to_string().contains("nonexistent"), "err: {err}");
 }
@@ -127,9 +175,16 @@ async fn stage_failure_returns_error() {
 
     provider.push_error("provider down");
 
-    let err = run_sequential(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .unwrap_err();
+    let err = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(matches!(err, WorkflowError::StageFailed { .. }));
 }
@@ -138,10 +193,12 @@ async fn stage_failure_returns_error() {
 
 #[tokio::test]
 async fn parallel_workflow_runs_all_stages() {
-    let file = parse_file(r#"
+    let file = parse_file(
+        r"
         agent a { model: openai }
         agent b { model: openai }
-    "#);
+    ",
+    );
     let mut workflow = make_workflow("pipe", "event", &["a", "b"]);
     workflow.mode = ExecutionMode::Parallel;
 
@@ -151,9 +208,16 @@ async fn parallel_workflow_runs_all_stages() {
     provider.push_response(simple_response("output_a"));
     provider.push_response(simple_response("output_b"));
 
-    let result = run_parallel(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("should succeed");
+    let result = run_parallel(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("should succeed");
 
     assert_eq!(result.stage_results.len(), 2);
     assert_eq!(result.stage_results[0].output, "output_a");
@@ -174,9 +238,16 @@ async fn parallel_unknown_agent_errors() {
     // Queue response for agent "a" so it doesn't fail first
     provider.push_response(simple_response("ok"));
 
-    let err = run_parallel(&workflow, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .unwrap_err();
+    let err = run_parallel(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(err.to_string().contains("missing"), "err: {err}");
 }
@@ -191,17 +262,187 @@ async fn run_workflow_dispatches_by_mode() {
     let mut seq = make_workflow("seq", "event", &["a"]);
     seq.mode = ExecutionMode::Sequential;
     provider.push_response(simple_response("sequential"));
-    let r1 = run_workflow(&seq, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("ok");
+    let r1 = run_workflow(
+        &seq,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("ok");
     assert_eq!(r1.final_output, "sequential");
 
     // Parallel
     let mut par = make_workflow("par", "event", &["a"]);
     par.mode = ExecutionMode::Parallel;
     provider.push_response(simple_response("parallel"));
-    let r2 = run_workflow(&par, &file, &provider, &executor, &[], &RunConfig::default())
-        .await
-        .expect("ok");
+    let r2 = run_workflow(
+        &par,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("ok");
     assert!(r2.final_output.contains("parallel"));
+}
+
+// ── Conditional routing tests ────────────────────────────────────────────
+
+fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
+    let file = parse_file(
+        r"
+        agent triage { model: openai }
+        agent respond { model: openai }
+        agent escalate { model: openai }
+    ",
+    );
+
+    let workflow = WorkflowDef {
+        name: "support".to_string(),
+        trigger: "ticket".to_string(),
+        stages: vec![
+            Stage {
+                name: "triage".to_string(),
+                agent: "triage".to_string(),
+                route: RouteRule::Conditional {
+                    field: "priority".to_string(),
+                    equals: "high".to_string(),
+                    then_stage: "escalate".to_string(),
+                    else_stage: Some("respond".to_string()),
+                },
+                span: Span::new(0, 1),
+            },
+            Stage {
+                name: "escalate".to_string(),
+                agent: "escalate".to_string(),
+                route: RouteRule::Next,
+                span: Span::new(0, 1),
+            },
+            Stage {
+                name: "respond".to_string(),
+                agent: "respond".to_string(),
+                route: RouteRule::Next,
+                span: Span::new(0, 1),
+            },
+        ],
+        mode: ExecutionMode::Sequential,
+        span: Span::new(0, 1),
+    };
+
+    (file, workflow)
+}
+
+#[tokio::test]
+async fn conditional_routes_to_then_stage() {
+    let (file, workflow) = make_conditional_workflow();
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    // triage → escalate (conditional match) → respond (Next from escalate)
+    provider.push_response(simple_response("Priority: high. Urgent billing issue."));
+    provider.push_response(simple_response("Escalated to manager."));
+    provider.push_response(simple_response("Final response after escalation."));
+
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("ok");
+
+    assert_eq!(result.stage_results.len(), 3);
+    assert_eq!(result.stage_results[0].stage_name, "triage");
+    assert_eq!(result.stage_results[1].stage_name, "escalate");
+    assert_eq!(result.stage_results[2].stage_name, "respond");
+    assert_eq!(result.final_output, "Final response after escalation.");
+}
+
+#[tokio::test]
+async fn conditional_routes_to_else_stage() {
+    let (file, workflow) = make_conditional_workflow();
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("Priority: low. Simple question."));
+    provider.push_response(simple_response("Here's your answer."));
+
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("ok");
+
+    assert_eq!(result.stage_results.len(), 2);
+    assert_eq!(result.stage_results[0].stage_name, "triage");
+    assert_eq!(result.stage_results[1].stage_name, "respond");
+    assert_eq!(result.final_output, "Here's your answer.");
+}
+
+#[tokio::test]
+async fn conditional_no_else_ends_workflow() {
+    let file = parse_file(
+        r"
+        agent checker { model: openai }
+        agent handler { model: openai }
+    ",
+    );
+
+    let workflow = WorkflowDef {
+        name: "check".to_string(),
+        trigger: "event".to_string(),
+        stages: vec![
+            Stage {
+                name: "checker".to_string(),
+                agent: "checker".to_string(),
+                route: RouteRule::Conditional {
+                    field: "needs_action".to_string(),
+                    equals: "yes".to_string(),
+                    then_stage: "handler".to_string(),
+                    else_stage: None,
+                },
+                span: Span::new(0, 1),
+            },
+            Stage {
+                name: "handler".to_string(),
+                agent: "handler".to_string(),
+                route: RouteRule::Next,
+                span: Span::new(0, 1),
+            },
+        ],
+        mode: ExecutionMode::Sequential,
+        span: Span::new(0, 1),
+    };
+
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+
+    provider.push_response(simple_response("needs_action: no. All clear."));
+
+    let result = run_sequential(
+        &workflow,
+        &file,
+        &provider,
+        &executor,
+        &[],
+        &RunConfig::default(),
+    )
+    .await
+    .expect("ok");
+
+    assert_eq!(result.stage_results.len(), 1);
+    assert_eq!(result.stage_results[0].stage_name, "checker");
 }


### PR DESCRIPTION
Implements conditional routing for workflow stages based on agent output field matching.

## Changes
- Added `condition_matches()` function that parses agent output for `field: value` or `field=value` patterns
- Added `find_stage()` helper for named stage lookup
- Rewrote `run_sequential()` to respect `RouteRule::Conditional` with then/else branching
- Added `WorkflowError::StageNotFound` for invalid route targets
- Circular routing protection via visited set

## Tests (4 new)
- `conditional_routes_to_then_stage` — condition matches, routes to then_stage
- `conditional_routes_to_else_stage` — condition doesn't match, routes to else_stage  
- `conditional_no_else_ends_workflow` — no else + no match = workflow ends
- `conditional_stage_not_found_errors` — invalid route target returns error

Also fixed pre-existing clippy warnings (unnecessary raw string hashes) in workflow tests.

Closes #77