### PR TITLE
feat(parser): implement provider block parsing. Closes #114

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -118,6 +118,21 @@ pub struct AgentDef {
 }
 
 // ---------------------------------------------------------------------------
+// Provider types
+// ---------------------------------------------------------------------------
+
+/// A `provider <name> { ... }` definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderDef {
+    pub name: String,
+    /// The default model for this provider (e.g. `claude-haiku`, `gpt-4o`).
+    pub model: Option<ValueExpr>,
+    /// API key or credential reference (e.g. `env("ANTHROPIC_KEY")`).
+    pub key: Option<ValueExpr>,
+    pub span: Span,
+}
+
+// ---------------------------------------------------------------------------
 // Workflow types
 // ---------------------------------------------------------------------------
 
@@ -173,9 +188,10 @@ pub struct WorkflowDef {
 // Top-level file
 // ---------------------------------------------------------------------------
 
-/// Top-level parsed file — agent and workflow definitions.
+/// Top-level parsed file — provider, agent, and workflow definitions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReinFile {
+    pub providers: Vec<ProviderDef>,
     pub agents: Vec<AgentDef>,
     pub workflows: Vec<WorkflowDef>,
 }
@@ -286,6 +302,7 @@ mod tests {
     #[test]
     fn rein_file_roundtrips_via_json() {
         let file = ReinFile {
+            providers: vec![],
             agents: vec![AgentDef {
                 name: "bot".to_string(),
                 model: None,
@@ -392,6 +409,7 @@ mod tests {
     #[test]
     fn rein_file_with_workflows_roundtrips() {
         let file = ReinFile {
+            providers: vec![],
             agents: vec![],
             workflows: vec![WorkflowDef {
                 name: "pipeline".to_string(),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -15,6 +15,8 @@ pub enum TokenKind {
     Workflow,
     Trigger,
     Stages,
+    Provider,
+    Key,
     // Symbols
     LBrace,
     RBrace,
@@ -57,6 +59,8 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Workflow => write!(f, "workflow"),
             TokenKind::Trigger => write!(f, "trigger"),
             TokenKind::Stages => write!(f, "stages"),
+            TokenKind::Provider => write!(f, "provider"),
+            TokenKind::Key => write!(f, "key"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Dollar(n) => write!(f, "${}.{:02}", n / 100, n % 100),
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
@@ -171,6 +175,8 @@ impl<'a> Lexer<'a> {
             "workflow" => TokenKind::Workflow,
             "trigger" => TokenKind::Trigger,
             "stages" => TokenKind::Stages,
+            "provider" => TokenKind::Provider,
+            "key" => TokenKind::Key,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    AgentDef, Budget, Capability, Constraint, ExecutionMode, ReinFile, RouteRule, Span, Stage,
-    ValueExpr, WorkflowDef,
+    AgentDef, Budget, Capability, Constraint, ExecutionMode, ProviderDef, ReinFile, RouteRule,
+    Span, Stage, ValueExpr, WorkflowDef,
 };
 use crate::lexer::{Token, TokenKind, tokenize};
 
@@ -172,22 +172,90 @@ impl Parser {
 
     pub fn parse_file(&mut self) -> Result<ReinFile, ParseError> {
         self.skip_comments();
+        let mut providers = Vec::new();
         let mut agents = Vec::new();
         let mut workflows = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
+                TokenKind::Provider => providers.push(self.parse_provider()?),
                 TokenKind::Agent => agents.push(self.parse_agent()?),
                 TokenKind::Workflow => workflows.push(self.parse_workflow()?),
                 other => {
                     return Err(ParseError::new(
-                        format!("expected 'agent' or 'workflow', got {other}"),
+                        format!("expected 'provider', 'agent', or 'workflow', got {other}"),
                         self.current_span(),
                     ));
                 }
             }
             self.skip_comments();
         }
-        Ok(ReinFile { agents, workflows })
+        Ok(ReinFile {
+            providers,
+            agents,
+            workflows,
+        })
+    }
+
+    fn parse_provider(&mut self) -> Result<ProviderDef, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Provider)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut model: Option<ValueExpr> = None;
+        let mut key: Option<ValueExpr> = None;
+        let mut seen_model = false;
+        let mut seen_key = false;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(ProviderDef {
+                        name,
+                        model,
+                        key,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Model => {
+                    if seen_model {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'model' in provider '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_model = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    model = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Key => {
+                    if seen_key {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'key' in provider '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_key = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    key = Some(self.parse_value_expr()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!(
+                            "unexpected field in provider '{name}': {other}"
+                        ),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
     }
 
     fn parse_agent(&mut self) -> Result<AgentDef, ParseError> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -458,3 +458,59 @@ fn parse_multiple_workflows() {
     assert_eq!(file.workflows[0].name, "w1");
     assert_eq!(file.workflows[1].name, "w2");
 }
+
+// ── Provider block tests ──────────────────────────────────────────────────
+
+#[test]
+fn parse_provider_basic() {
+    let f = parse_ok(r#"provider anthropic { model: "claude-haiku" key: env("ANTHROPIC_KEY") }"#);
+    assert_eq!(f.providers.len(), 1);
+    assert_eq!(f.providers[0].name, "anthropic");
+    assert_eq!(
+        f.providers[0].model.as_ref().and_then(|v| v.as_literal()),
+        Some("claude-haiku")
+    );
+    match &f.providers[0].key {
+        Some(crate::ast::ValueExpr::EnvRef { var_name, .. }) => {
+            assert_eq!(var_name, "ANTHROPIC_KEY");
+        }
+        other => panic!("expected EnvRef, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_provider_model_only() {
+    let f = parse_ok(r#"provider openai { model: "gpt-4o" }"#);
+    assert_eq!(f.providers[0].name, "openai");
+    assert!(f.providers[0].key.is_none());
+}
+
+#[test]
+fn parse_multiple_providers() {
+    let src = r#"
+        provider anthropic { model: "claude-haiku" key: env("A_KEY") }
+        provider openai { model: "gpt-4o" key: env("O_KEY") }
+        agent test { model: openai }
+    "#;
+    let f = parse_ok(src);
+    assert_eq!(f.providers.len(), 2);
+    assert_eq!(f.agents.len(), 1);
+}
+
+#[test]
+fn parse_provider_duplicate_model_errors() {
+    let err = parse_err("provider x { model: a model: b }");
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_provider_duplicate_key_errors() {
+    let err = parse_err(r#"provider x { key: env("A") key: env("B") }"#);
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_provider_unknown_field_errors() {
+    let err = parse_err("provider x { model: a budget: $5 }");
+    assert!(err.message.contains("unexpected"), "got: {}", err.message);
+}

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AgentDef, Constraint, ReinFile, Span};
+use crate::ast::{AgentDef, Constraint, ProviderDef, ReinFile, Span};
 
 /// Severity of a diagnostic.
 #[derive(Debug, Clone, PartialEq)]
@@ -44,6 +44,10 @@ impl Diagnostic {
 /// Returns a list of diagnostics (errors and warnings).
 pub fn validate(file: &ReinFile) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
+    check_duplicate_provider_names(file, &mut diags);
+    for provider in &file.providers {
+        check_provider_key_present(provider, &mut diags);
+    }
     check_duplicate_agent_names(file, &mut diags);
     for agent in &file.agents {
         check_can_cannot_overlap(agent, &mut diags);
@@ -225,6 +229,37 @@ fn check_model_present(agent: &AgentDef, diags: &mut Vec<Diagnostic>) {
             "W001",
             format!("agent '{}' has no `model` field", agent.name),
             agent.span.clone(),
+        ));
+    }
+}
+
+/// E007: two providers with the same name.
+fn check_duplicate_provider_names(file: &ReinFile, diags: &mut Vec<Diagnostic>) {
+    use std::collections::HashMap;
+    let mut seen: HashMap<&str, &ProviderDef> = HashMap::new();
+    for provider in &file.providers {
+        if let Some(first) = seen.get(provider.name.as_str()) {
+            diags.push(Diagnostic::error(
+                "E007",
+                format!(
+                    "duplicate provider name '{}': first defined at {}",
+                    provider.name, first.span.start
+                ),
+                provider.span.clone(),
+            ));
+        } else {
+            seen.insert(&provider.name, provider);
+        }
+    }
+}
+
+/// W005: provider has no `key` field.
+fn check_provider_key_present(provider: &ProviderDef, diags: &mut Vec<Diagnostic>) {
+    if provider.key.is_none() {
+        diags.push(Diagnostic::warning(
+            "W005",
+            format!("provider '{}' has no `key` field", provider.name),
+            provider.span.clone(),
         ));
     }
 }

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -79,6 +79,7 @@ fn zero_budget_detected() {
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile {
+        providers: vec![],
         agents: vec![AgentDef {
             name: "bot".into(),
             model: Some(ValueExpr::Literal("anthropic".into())),
@@ -246,4 +247,30 @@ fn workflow_duplicate_stages_warns() {
     let warns = warnings(&diags);
     assert_eq!(warns.len(), 1);
     assert_eq!(warns[0].code, "W004");
+}
+
+// ── Provider validation tests ─────────────────────────────────────────────
+
+#[test]
+fn duplicate_provider_names_error() {
+    let diags = validate_src(r#"
+        provider openai { model: "gpt-4o" key: env("K1") }
+        provider openai { model: "gpt-4o-mini" key: env("K2") }
+    "#);
+    let errors: Vec<_> = diags.iter().filter(|d| d.code == "E007").collect();
+    assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn provider_missing_key_warns() {
+    let diags = validate_src("provider openai { model: openai }");
+    let warns: Vec<_> = diags.iter().filter(|d| d.code == "W005").collect();
+    assert_eq!(warns.len(), 1);
+}
+
+#[test]
+fn provider_with_key_no_warning() {
+    let diags = validate_src(r#"provider openai { model: openai key: env("K") }"#);
+    let warns: Vec<_> = diags.iter().filter(|d| d.code == "W005").collect();
+    assert_eq!(warns.len(), 0);
 }


### PR DESCRIPTION
Adds provider block support: `provider <name> { model: <val> key: <val> }`

- ProviderDef AST type with model/key ValueExpr fields
- Provider/Key lexer keywords
- parse_provider() parser method
- Validator: E007 (duplicate names), W005 (missing key)
- 8 new tests (5 parser + 3 validator)
- Manual QA: rein validate passes with multi-provider .rein files

277 total tests, zero clippy.