### PR TITLE
feat(parser): implement tool block definitions. Closes #116

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -134,6 +134,23 @@ pub struct ProviderDef {
 }
 
 // ---------------------------------------------------------------------------
+// Tool types
+// ---------------------------------------------------------------------------
+
+/// A tool block: `tool zendesk { endpoint: "https://..." }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    /// The endpoint URL for this tool.
+    pub endpoint: Option<ValueExpr>,
+    /// Optional provider type (e.g. `rest_api`, `mcp`).
+    pub provider: Option<ValueExpr>,
+    /// Optional API key or credential reference.
+    pub key: Option<ValueExpr>,
+    pub span: Span,
+}
+
+// ---------------------------------------------------------------------------
 // Workflow types
 // ---------------------------------------------------------------------------
 
@@ -206,6 +223,7 @@ pub struct WorkflowDef {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReinFile {
     pub providers: Vec<ProviderDef>,
+    pub tools: Vec<ToolDef>,
     pub agents: Vec<AgentDef>,
     pub workflows: Vec<WorkflowDef>,
 }
@@ -317,6 +335,7 @@ mod tests {
     fn rein_file_roundtrips_via_json() {
         let file = ReinFile {
             providers: vec![],
+            tools: vec![],
             agents: vec![AgentDef {
                 name: "bot".to_string(),
                 model: None,
@@ -426,6 +445,7 @@ mod tests {
     fn rein_file_with_workflows_roundtrips() {
         let file = ReinFile {
             providers: vec![],
+            tools: vec![],
             agents: vec![],
             workflows: vec![WorkflowDef {
                 name: "pipeline".to_string(),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -19,6 +19,8 @@ pub enum TokenKind {
     Key,
     Step,
     Goal,
+    Tool,
+    Endpoint,
     // Symbols
     LBrace,
     RBrace,
@@ -65,6 +67,8 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Key => write!(f, "key"),
             TokenKind::Step => write!(f, "step"),
             TokenKind::Goal => write!(f, "goal"),
+            TokenKind::Tool => write!(f, "tool"),
+            TokenKind::Endpoint => write!(f, "endpoint"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Dollar(n) => write!(f, "${}.{:02}", n / 100, n % 100),
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
@@ -183,6 +187,8 @@ impl<'a> Lexer<'a> {
             "key" => TokenKind::Key,
             "step" => TokenKind::Step,
             "goal" => TokenKind::Goal,
+            "tool" => TokenKind::Tool,
+            "endpoint" => TokenKind::Endpoint,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -419,3 +419,13 @@ fn hash_comment_at_start_of_file_with_code() {
     assert_eq!(tokens[0].kind, TokenKind::Comment);
     assert_eq!(tokens[1].kind, TokenKind::Agent);
 }
+
+#[test]
+fn tool_and_endpoint_keywords() {
+    let src = "tool zendesk { endpoint: \"https://api.zendesk.com\" }";
+    let tokens = non_eof(lex_ok(src));
+    assert_eq!(tokens[0].kind, TokenKind::Tool);
+    assert_eq!(tokens[2].kind, TokenKind::LBrace);
+    assert_eq!(tokens[3].kind, TokenKind::Endpoint);
+    assert_eq!(tokens[4].kind, TokenKind::Colon);
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     AgentDef, Budget, Capability, Constraint, ExecutionMode, ProviderDef, ReinFile, RouteRule,
-    Span, Stage, ValueExpr, WorkflowDef,
+    Span, Stage, ToolDef, ValueExpr, WorkflowDef,
 };
 use crate::lexer::{Token, TokenKind, tokenize};
 
@@ -173,16 +173,18 @@ impl Parser {
     pub fn parse_file(&mut self) -> Result<ReinFile, ParseError> {
         self.skip_comments();
         let mut providers = Vec::new();
+        let mut tools = Vec::new();
         let mut agents = Vec::new();
         let mut workflows = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
                 TokenKind::Provider => providers.push(self.parse_provider()?),
+                TokenKind::Tool => tools.push(self.parse_tool()?),
                 TokenKind::Agent => agents.push(self.parse_agent()?),
                 TokenKind::Workflow => workflows.push(self.parse_workflow()?),
                 other => {
                     return Err(ParseError::new(
-                        format!("expected 'provider', 'agent', or 'workflow', got {other}"),
+                        format!("expected 'provider', 'tool', 'agent', or 'workflow', got {other}"),
                         self.current_span(),
                     ));
                 }
@@ -191,6 +193,7 @@ impl Parser {
         }
         Ok(ReinFile {
             providers,
+            tools,
             agents,
             workflows,
         })
@@ -249,6 +252,81 @@ impl Parser {
                 other => {
                     return Err(ParseError::new(
                         format!("unexpected field in provider '{name}': {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn parse_tool(&mut self) -> Result<ToolDef, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Tool)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut endpoint: Option<ValueExpr> = None;
+        let mut provider: Option<ValueExpr> = None;
+        let mut key: Option<ValueExpr> = None;
+        let mut seen_endpoint = false;
+        let mut seen_provider = false;
+        let mut seen_key = false;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(ToolDef {
+                        name,
+                        endpoint,
+                        provider,
+                        key,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Endpoint => {
+                    if seen_endpoint {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'endpoint' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_endpoint = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    endpoint = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Provider => {
+                    if seen_provider {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'provider' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_provider = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    provider = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Key => {
+                    if seen_key {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'key' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_key = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    key = Some(self.parse_value_expr()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected field in tool '{name}': {other}"),
                         self.current_span(),
                     ));
                 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -705,3 +705,92 @@ fn parse_workflow_mixed_stages_and_steps() {
     assert_eq!(f.workflows[0].stages.len(), 1);
     assert_eq!(f.workflows[0].steps.len(), 1);
 }
+
+// ───── Tool block tests ─────
+
+#[test]
+fn parse_tool_with_endpoint() {
+    let f = parse_ok(r#"tool zendesk { endpoint: "https://api.zendesk.com/v2" }"#);
+    assert_eq!(f.tools.len(), 1);
+    assert_eq!(f.tools[0].name, "zendesk");
+    assert!(f.tools[0].endpoint.is_some());
+}
+
+#[test]
+fn parse_tool_with_all_fields() {
+    let f = parse_ok(
+        r#"tool zendesk {
+            provider: rest_api
+            endpoint: "https://api.zendesk.com/v2"
+            key: env("ZENDESK_KEY")
+        }"#,
+    );
+    assert_eq!(f.tools[0].name, "zendesk");
+    assert!(f.tools[0].provider.is_some());
+    assert!(f.tools[0].endpoint.is_some());
+    assert!(f.tools[0].key.is_some());
+}
+
+#[test]
+fn parse_tool_empty_block() {
+    let f = parse_ok("tool empty_tool {}");
+    assert_eq!(f.tools.len(), 1);
+    assert_eq!(f.tools[0].name, "empty_tool");
+    assert!(f.tools[0].endpoint.is_none());
+}
+
+#[test]
+fn parse_tool_endpoint_env_ref() {
+    let f = parse_ok(r#"tool api { endpoint: env("API_URL") }"#);
+    assert!(f.tools[0].endpoint.is_some());
+}
+
+#[test]
+fn parse_tool_duplicate_endpoint_errors() {
+    let err = parse_err(
+        r#"tool z {
+            endpoint: "a"
+            endpoint: "b"
+        }"#,
+    );
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_tool_duplicate_provider_errors() {
+    let err = parse_err(
+        r#"tool z {
+            provider: rest
+            provider: mcp
+        }"#,
+    );
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_tool_duplicate_key_errors() {
+    let err = parse_err(
+        r#"tool z {
+            key: env("A")
+            key: env("B")
+        }"#,
+    );
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_tool_unknown_field_errors() {
+    let err = parse_err(r#"tool z { foo: bar }"#);
+    assert!(err.message.contains("unexpected"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_multiple_tools() {
+    let f = parse_ok(
+        r#"
+        tool zendesk { endpoint: "https://zendesk.com" }
+        tool shopify { endpoint: "https://shopify.com" }
+    "#,
+    );
+    assert_eq!(f.tools.len(), 2);
+}

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AgentDef, Constraint, ProviderDef, ReinFile, Span};
+use crate::ast::{AgentDef, Constraint, ProviderDef, ReinFile, Span, ToolDef};
 
 /// Severity of a diagnostic.
 #[derive(Debug, Clone, PartialEq)]
@@ -45,6 +45,7 @@ impl Diagnostic {
 pub fn validate(file: &ReinFile) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     check_duplicate_provider_names(file, &mut diags);
+    check_duplicate_tool_names(file, &mut diags);
     for provider in &file.providers {
         check_provider_key_present(provider, &mut diags);
     }
@@ -317,6 +318,26 @@ fn check_duplicate_provider_names(file: &ReinFile, diags: &mut Vec<Diagnostic>) 
             ));
         } else {
             seen.insert(&provider.name, provider);
+        }
+    }
+}
+
+/// E011: two tools with the same name.
+fn check_duplicate_tool_names(file: &ReinFile, diags: &mut Vec<Diagnostic>) {
+    use std::collections::HashMap;
+    let mut seen: HashMap<&str, &ToolDef> = HashMap::new();
+    for tool in &file.tools {
+        if let Some(first) = seen.get(tool.name.as_str()) {
+            diags.push(Diagnostic::error(
+                "E011",
+                format!(
+                    "duplicate tool name '{}': first defined at {}",
+                    tool.name, first.span.start
+                ),
+                tool.span.clone(),
+            ));
+        } else {
+            seen.insert(&tool.name, tool);
         }
     }
 }

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -80,6 +80,7 @@ fn zero_budget_detected() {
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile {
         providers: vec![],
+        tools: vec![],
         agents: vec![AgentDef {
             name: "bot".into(),
             model: Some(ValueExpr::Literal("anthropic".into())),
@@ -339,6 +340,19 @@ fn duplicate_step_names_error() {
     );
     let errors: Vec<_> = diags.iter().filter(|d| d.code == "E009").collect();
     assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn duplicate_tool_names_error() {
+    let diags = validate_src(
+        r#"
+        tool zendesk { endpoint: "https://a.com" }
+        tool zendesk { endpoint: "https://b.com" }
+    "#,
+    );
+    let errors: Vec<_> = diags.iter().filter(|d| d.code == "E011").collect();
+    assert_eq!(errors.len(), 1);
+    assert!(errors[0].message.contains("duplicate tool name"));
 }
 
 #[test]


### PR DESCRIPTION
Adds `tool` block parsing to the Rein DSL.

## Syntax

```hcl
tool zendesk {
    provider: rest_api
    endpoint: "https://api.zendesk.com/v2"
    key: env("ZENDESK_KEY")
}
```

All fields are optional and support `env()` references.

## Changes

- **Lexer:** `Tool` and `Endpoint` keywords
- **AST:** `ToolDef` struct, `tools: Vec<ToolDef>` on `ReinFile`
- **Parser:** `parse_tool()` with duplicate field detection
- **Validator:** E011 duplicate tool name check

## Tests

11 new tests (1 lexer, 9 parser, 1 validator). 300 total, all passing. Zero clippy warnings.