### PR TITLE
feat(parser): implement defaults block. Closes #120

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -120,6 +120,18 @@ pub struct AgentDef {
 }
 
 // ---------------------------------------------------------------------------
+// Defaults types
+// ---------------------------------------------------------------------------
+
+/// A `defaults { model: ..., budget: ... }` block providing project-level defaults.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DefaultsDef {
+    pub model: Option<ValueExpr>,
+    pub budget: Option<Budget>,
+    pub span: Span,
+}
+
+// ---------------------------------------------------------------------------
 // Guardrails types
 // ---------------------------------------------------------------------------
 
@@ -250,6 +262,7 @@ pub struct WorkflowDef {
 /// Top-level parsed file — provider, agent, and workflow definitions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReinFile {
+    pub defaults: Option<DefaultsDef>,
     pub providers: Vec<ProviderDef>,
     pub tools: Vec<ToolDef>,
     pub agents: Vec<AgentDef>,
@@ -363,6 +376,7 @@ mod tests {
     #[test]
     fn rein_file_roundtrips_via_json() {
         let file = ReinFile {
+            defaults: None,
             providers: vec![],
             tools: vec![],
             agents: vec![AgentDef {
@@ -475,6 +489,7 @@ mod tests {
     #[test]
     fn rein_file_with_workflows_roundtrips() {
         let file = ReinFile {
+            defaults: None,
             providers: vec![],
             tools: vec![],
             agents: vec![],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -22,6 +22,7 @@ pub enum TokenKind {
     Tool,
     Endpoint,
     Guardrails,
+    Defaults,
     // Symbols
     LBrace,
     RBrace,
@@ -71,6 +72,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Tool => write!(f, "tool"),
             TokenKind::Endpoint => write!(f, "endpoint"),
             TokenKind::Guardrails => write!(f, "guardrails"),
+            TokenKind::Defaults => write!(f, "defaults"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Dollar(n) => write!(f, "${}.{:02}", n / 100, n % 100),
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
@@ -192,6 +194,7 @@ impl<'a> Lexer<'a> {
             "tool" => TokenKind::Tool,
             "endpoint" => TokenKind::Endpoint,
             "guardrails" => TokenKind::Guardrails,
+            "defaults" => TokenKind::Defaults,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -421,6 +421,13 @@ fn hash_comment_at_start_of_file_with_code() {
 }
 
 #[test]
+fn defaults_keyword() {
+    let src = "defaults { model: openai }";
+    let tokens = non_eof(lex_ok(src));
+    assert_eq!(tokens[0].kind, TokenKind::Defaults);
+}
+
+#[test]
 fn guardrails_keyword() {
     let src = "guardrails { }";
     let tokens = non_eof(lex_ok(src));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
 use crate::ast::{
-    AgentDef, Budget, Capability, Constraint, ExecutionMode, GuardrailRule, GuardrailSection,
-    GuardrailsDef, ProviderDef, ReinFile, RouteRule, Span, Stage, ToolDef, ValueExpr, WorkflowDef,
+    AgentDef, Budget, Capability, Constraint, DefaultsDef, ExecutionMode, GuardrailRule,
+    GuardrailSection, GuardrailsDef, ProviderDef, ReinFile, RouteRule, Span, Stage, ToolDef,
+    ValueExpr, WorkflowDef,
 };
 use crate::lexer::{Token, TokenKind, tokenize};
 
@@ -172,19 +173,31 @@ impl Parser {
 
     pub fn parse_file(&mut self) -> Result<ReinFile, ParseError> {
         self.skip_comments();
+        let mut defaults: Option<DefaultsDef> = None;
         let mut providers = Vec::new();
         let mut tools = Vec::new();
         let mut agents = Vec::new();
         let mut workflows = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
+                TokenKind::Defaults => {
+                    if defaults.is_some() {
+                        return Err(ParseError::new(
+                            "duplicate 'defaults' block (only one allowed per file)",
+                            self.current_span(),
+                        ));
+                    }
+                    defaults = Some(self.parse_defaults()?);
+                }
                 TokenKind::Provider => providers.push(self.parse_provider()?),
                 TokenKind::Tool => tools.push(self.parse_tool()?),
                 TokenKind::Agent => agents.push(self.parse_agent()?),
                 TokenKind::Workflow => workflows.push(self.parse_workflow()?),
                 other => {
                     return Err(ParseError::new(
-                        format!("expected 'provider', 'tool', 'agent', or 'workflow', got {other}"),
+                        format!(
+                            "expected 'defaults', 'provider', 'tool', 'agent', or 'workflow', got {other}"
+                        ),
                         self.current_span(),
                     ));
                 }
@@ -192,11 +205,67 @@ impl Parser {
             self.skip_comments();
         }
         Ok(ReinFile {
+            defaults,
             providers,
             tools,
             agents,
             workflows,
         })
+    }
+
+    fn parse_defaults(&mut self) -> Result<DefaultsDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Defaults)?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut model: Option<ValueExpr> = None;
+        let mut budget: Option<Budget> = None;
+        let (mut seen_model, mut seen_budget) = (false, false);
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(DefaultsDef {
+                        model,
+                        budget,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Model => {
+                    if seen_model {
+                        return Err(ParseError::new(
+                            "duplicate field 'model' in defaults block",
+                            self.current_span(),
+                        ));
+                    }
+                    seen_model = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    model = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Budget => {
+                    if seen_budget {
+                        return Err(ParseError::new(
+                            "duplicate field 'budget' in defaults block",
+                            self.current_span(),
+                        ));
+                    }
+                    seen_budget = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    budget = Some(self.parse_budget()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected field in defaults block: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
     }
 
     fn parse_provider(&mut self) -> Result<ProviderDef, ParseError> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -706,6 +706,76 @@ fn parse_workflow_mixed_stages_and_steps() {
     assert_eq!(f.workflows[0].steps.len(), 1);
 }
 
+// ───── Defaults block tests ─────
+
+#[test]
+fn parse_defaults_with_model() {
+    let f = parse_ok("defaults { model: anthropic }");
+    let d = f.defaults.unwrap();
+    assert!(d.model.is_some());
+    assert!(d.budget.is_none());
+}
+
+#[test]
+fn parse_defaults_with_budget() {
+    let f = parse_ok("defaults { budget: $0.05 per run }");
+    let d = f.defaults.unwrap();
+    assert!(d.budget.is_some());
+    assert_eq!(d.budget.unwrap().amount, 5);
+}
+
+#[test]
+fn parse_defaults_with_all_fields() {
+    let f = parse_ok("defaults { model: anthropic budget: $1.00 per request }");
+    let d = f.defaults.unwrap();
+    assert!(d.model.is_some());
+    assert!(d.budget.is_some());
+}
+
+#[test]
+fn parse_defaults_empty() {
+    let f = parse_ok("defaults {}");
+    let d = f.defaults.unwrap();
+    assert!(d.model.is_none());
+    assert!(d.budget.is_none());
+}
+
+#[test]
+fn parse_defaults_before_agents() {
+    let f = parse_ok(
+        r#"
+        defaults { model: openai }
+        agent bot { can [zendesk.read] }
+    "#,
+    );
+    assert!(f.defaults.is_some());
+    assert_eq!(f.agents.len(), 1);
+}
+
+#[test]
+fn parse_duplicate_defaults_errors() {
+    let err = parse_err("defaults {} defaults {}");
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_defaults_duplicate_model_errors() {
+    let err = parse_err("defaults { model: a model: b }");
+    assert!(err.message.contains("duplicate"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_defaults_unknown_field_errors() {
+    let err = parse_err("defaults { foo: bar }");
+    assert!(err.message.contains("unexpected"), "got: {}", err.message);
+}
+
+#[test]
+fn parse_no_defaults() {
+    let f = parse_ok("agent bot { model: openai }");
+    assert!(f.defaults.is_none());
+}
+
 // ───── Guardrails tests ─────
 
 #[test]

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -79,6 +79,7 @@ fn zero_budget_detected() {
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile {
+        defaults: None,
         providers: vec![],
         tools: vec![],
         agents: vec![AgentDef {


### PR DESCRIPTION
Adds `defaults` block parsing for project-level agent defaults.

## Syntax

```hcl
defaults {
    model: anthropic
    budget: $0.05 per run
}

agent support {
    # inherits model and budget from defaults
    budget: $0.03 per ticket  # override
}
```

## Changes

- **Lexer:** `Defaults` keyword
- **AST:** `DefaultsDef` struct, `defaults: Option<DefaultsDef>` on `ReinFile`
- **Parser:** `parse_defaults()` with duplicate field/block detection
- Only one defaults block per file (enforced at parse time)

## Note

This PR adds parsing only. Validator-level expansion (applying defaults to agents that don't override) is a follow-up.

## Tests

10 new tests. 317 total, all passing. Zero clippy warnings.