### PR TITLE
feat(lexer): support multi-currency symbols. Closes #133

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -35,7 +35,11 @@ pub enum TokenKind {
     // Literals
     Ident(String),
     StringLiteral(String),
-    Dollar(u64),
+    /// A monetary amount with currency symbol and value in minor units (cents).
+    Currency {
+        symbol: char,
+        amount: u64,
+    },
     // Trivia
     Comment,
     Eof,
@@ -72,7 +76,9 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Endpoint => write!(f, "endpoint"),
             TokenKind::Guardrails => write!(f, "guardrails"),
             TokenKind::Ident(s) => write!(f, "{s}"),
-            TokenKind::Dollar(n) => write!(f, "${}.{:02}", n / 100, n % 100),
+            TokenKind::Currency { symbol, amount } => {
+                write!(f, "{symbol}{}.{:02}", amount / 100, amount % 100)
+            }
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
             TokenKind::Comment => write!(f, "comment"),
             TokenKind::Eof => write!(f, "end of file"),
@@ -197,16 +203,14 @@ impl<'a> Lexer<'a> {
         Token::new(kind, start, end)
     }
 
-    fn read_dollar(&mut self, start: usize) -> Result<Token, LexError> {
-        // already consumed '$' at start; pos is now one past '$'
-
-        // The character immediately after '$' must be an ASCII digit.
+    fn read_currency(&mut self, symbol: char, start: usize) -> Result<Token, LexError> {
+        // Already consumed currency symbol at start; pos is now past it.
         match self.peek() {
             Some(b'0'..=b'9') => {}
             Some(ch) => {
                 return Err(LexError {
                     message: format!(
-                        "invalid dollar amount: expected a number after '$', found '{}'",
+                        "invalid currency amount: expected a number after '{symbol}', found '{}'",
                         ch as char
                     ),
                     span: Span::new(start, self.pos + 1),
@@ -214,9 +218,9 @@ impl<'a> Lexer<'a> {
             }
             None => {
                 return Err(LexError {
-                    message:
-                        "invalid dollar amount: expected a number after '$', found end of input"
-                            .to_string(),
+                    message: format!(
+                        "invalid currency amount: expected a number after '{symbol}', found end of input"
+                    ),
                     span: Span::new(start, self.pos),
                 });
             }
@@ -224,22 +228,19 @@ impl<'a> Lexer<'a> {
 
         let num_start = self.pos;
 
-        // Consume the integer part.
         while matches!(self.peek(), Some(b'0'..=b'9')) {
             self.advance();
         }
 
-        // Optional decimal part.
         if self.peek() == Some(b'.') {
-            self.advance(); // consume '.'
+            self.advance();
 
-            // A digit must immediately follow the decimal point.
             match self.peek() {
                 Some(b'0'..=b'9') => {}
                 Some(ch) => {
                     return Err(LexError {
                         message: format!(
-                            "invalid dollar amount: expected digit after decimal point, found '{}'",
+                            "invalid currency amount: expected digit after decimal point, found '{}'",
                             ch as char
                         ),
                         span: Span::new(start, self.pos + 1),
@@ -247,22 +248,20 @@ impl<'a> Lexer<'a> {
                 }
                 None => {
                     return Err(LexError {
-                        message: "invalid dollar amount: expected digit after decimal point, found end of input"
+                        message: "invalid currency amount: expected digit after decimal point, found end of input"
                             .to_string(),
                         span: Span::new(start, self.pos),
                     });
                 }
             }
 
-            // Consume the fractional digits.
             while matches!(self.peek(), Some(b'0'..=b'9')) {
                 self.advance();
             }
 
-            // A second decimal point is never valid.
             if self.peek() == Some(b'.') {
                 return Err(LexError {
-                    message: "invalid dollar amount: too many decimal points".to_string(),
+                    message: "invalid currency amount: too many decimal points".to_string(),
                     span: Span::new(start, self.pos + 1),
                 });
             }
@@ -270,10 +269,17 @@ impl<'a> Lexer<'a> {
 
         let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).unwrap();
         let cents = parse_cents(num_str).map_err(|()| LexError {
-            message: format!("invalid dollar amount: '${num_str}'"),
+            message: format!("invalid currency amount: '{symbol}{num_str}'"),
             span: Span::new(start, self.pos),
         })?;
-        Ok(Token::new(TokenKind::Dollar(cents), start, self.pos))
+        Ok(Token::new(
+            TokenKind::Currency {
+                symbol,
+                amount: cents,
+            },
+            start,
+            self.pos,
+        ))
     }
 
     fn read_string(&mut self, start: usize) -> Result<Token, LexError> {
@@ -344,7 +350,7 @@ impl<'a> Lexer<'a> {
                 Some(b'.') => tokens.push(Token::new(TokenKind::Dot, start, self.pos)),
                 Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
                 Some(b'"') => tokens.push(self.read_string(start)?),
-                Some(b'$') => tokens.push(self.read_dollar(start)?),
+                Some(b'$') => tokens.push(self.read_currency('$', start)?),
                 Some(b'#') => {
                     tokens.push(self.skip_line_comment(start));
                 }
@@ -358,6 +364,25 @@ impl<'a> Lexer<'a> {
                 }
                 Some(ch) if ch.is_ascii_alphabetic() || ch == b'_' => {
                     tokens.push(self.read_ident(start));
+                }
+                // Multi-byte currency symbols: £ (C2 A3), ¥ (C2 A5), € (E2 82 AC)
+                Some(0xC2) if matches!(self.peek(), Some(0xA3 | 0xA5)) => {
+                    let sym = if self.src[self.pos] == 0xA3 {
+                        '£'
+                    } else {
+                        '¥'
+                    };
+                    self.advance(); // consume second byte
+                    tokens.push(self.read_currency(sym, start)?);
+                }
+                Some(0xE2)
+                    if self.pos + 1 < self.src.len()
+                        && self.src[self.pos] == 0x82
+                        && self.src[self.pos + 1] == 0xAC =>
+                {
+                    self.advance(); // consume 0x82
+                    self.advance(); // consume 0xAC
+                    tokens.push(self.read_currency('€', start)?);
                 }
                 Some(ch) => {
                     return Err(LexError {

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -60,13 +60,25 @@ fn tokenize_agent_header() {
 #[test]
 fn tokenize_dollar_amount() {
     let tokens = non_eof(lex_ok("$0.03"));
-    assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(3)]);
+    assert_eq!(
+        kinds(&tokens),
+        vec![&TokenKind::Currency {
+            symbol: '$',
+            amount: 3
+        }]
+    );
 }
 
 #[test]
 fn tokenize_dollar_integer() {
     let tokens = non_eof(lex_ok("$50"));
-    assert_eq!(kinds(&tokens), vec![&TokenKind::Dollar(5000)]);
+    assert_eq!(
+        kinds(&tokens),
+        vec![&TokenKind::Currency {
+            symbol: '$',
+            amount: 5000
+        }]
+    );
 }
 
 #[test]
@@ -87,7 +99,14 @@ fn tokenize_up_to_constraint() {
     let tokens = non_eof(lex_ok("up to $50"));
     assert_eq!(
         kinds(&tokens),
-        vec![&TokenKind::Up, &TokenKind::To, &TokenKind::Dollar(5000)]
+        vec![
+            &TokenKind::Up,
+            &TokenKind::To,
+            &TokenKind::Currency {
+                symbol: '$',
+                amount: 5000
+            }
+        ]
     );
 }
 
@@ -154,7 +173,11 @@ budget: $0.03 per ticket
     assert!(tokens.iter().any(|t| t.kind == TokenKind::Model));
     assert!(tokens.iter().any(|t| t.kind == TokenKind::Can));
     assert!(tokens.iter().any(|t| t.kind == TokenKind::Budget));
-    assert!(tokens.iter().any(|t| t.kind == TokenKind::Dollar(3)));
+    assert!(tokens.iter().any(|t| t.kind
+        == TokenKind::Currency {
+            symbol: '$',
+            amount: 3
+        }));
     assert!(tokens.iter().any(|t| t.kind == TokenKind::Per));
 }
 
@@ -339,17 +362,86 @@ fn display_ident() {
 
 #[test]
 fn display_dollar_cents_only() {
-    assert_eq!(TokenKind::Dollar(3).to_string(), "$0.03");
+    assert_eq!(
+        TokenKind::Currency {
+            symbol: '$',
+            amount: 3
+        }
+        .to_string(),
+        "$0.03"
+    );
 }
 
 #[test]
 fn display_dollar_whole() {
-    assert_eq!(TokenKind::Dollar(5000).to_string(), "$50.00");
+    assert_eq!(
+        TokenKind::Currency {
+            symbol: '$',
+            amount: 5000
+        }
+        .to_string(),
+        "$50.00"
+    );
 }
 
 #[test]
 fn display_dollar_mixed() {
-    assert_eq!(TokenKind::Dollar(503).to_string(), "$5.03");
+    assert_eq!(
+        TokenKind::Currency {
+            symbol: '$',
+            amount: 503
+        }
+        .to_string(),
+        "$5.03"
+    );
+}
+
+#[test]
+fn tokenize_euro() {
+    let tokens = non_eof(lex_ok("€10.50"));
+    assert_eq!(
+        tokens[0].kind,
+        TokenKind::Currency {
+            symbol: '€',
+            amount: 1050
+        }
+    );
+}
+
+#[test]
+fn tokenize_pound() {
+    let tokens = non_eof(lex_ok("£5.00"));
+    assert_eq!(
+        tokens[0].kind,
+        TokenKind::Currency {
+            symbol: '£',
+            amount: 500
+        }
+    );
+}
+
+#[test]
+fn tokenize_yen() {
+    let tokens = non_eof(lex_ok("¥100"));
+    assert_eq!(
+        tokens[0].kind,
+        TokenKind::Currency {
+            symbol: '¥',
+            amount: 10000
+        }
+    );
+}
+
+#[test]
+fn display_euro() {
+    assert_eq!(
+        TokenKind::Currency {
+            symbol: '€',
+            amount: 1050
+        }
+        .to_string(),
+        "€10.50"
+    );
 }
 
 #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -776,10 +776,16 @@ impl Parser {
         let constraint = if self.peek() == &TokenKind::Up {
             self.advance();
             self.expect(&TokenKind::To)?;
-            let (amount, _) = self.expect_dollar()?;
+            let (amount, symbol, _) = self.expect_currency()?;
+            let currency = match symbol {
+                '€' => "EUR",
+                '£' => "GBP",
+                '¥' => "JPY",
+                _ => "USD",
+            };
             Some(Constraint::MonetaryCap {
                 amount,
-                currency: "USD".to_string(),
+                currency: currency.to_string(),
             })
         } else {
             None
@@ -794,16 +800,16 @@ impl Parser {
         })
     }
 
-    fn expect_dollar(&mut self) -> Result<(u64, Span), ParseError> {
+    fn expect_currency(&mut self) -> Result<(u64, char, Span), ParseError> {
         self.skip_comments();
         let tok = self.current().clone();
         match tok.kind {
-            TokenKind::Dollar(amount) => {
+            TokenKind::Currency { amount, symbol } => {
                 self.advance();
-                Ok((amount, tok.span))
+                Ok((amount, symbol, tok.span))
             }
             _ => Err(ParseError::new(
-                format!("expected dollar amount, got {}", tok.kind),
+                format!("expected currency amount, got {}", tok.kind),
                 tok.span,
             )),
         }
@@ -811,13 +817,19 @@ impl Parser {
 
     fn parse_budget(&mut self) -> Result<Budget, ParseError> {
         let start = self.current_span().start;
-        let (amount, _) = self.expect_dollar()?;
+        let (amount, symbol, _) = self.expect_currency()?;
         self.expect(&TokenKind::Per)?;
         let (unit, _) = self.expect_ident()?;
         let end = self.last_consumed_end;
+        let currency = match symbol {
+            '€' => "EUR",
+            '£' => "GBP",
+            '¥' => "JPY",
+            _ => "USD",
+        };
         Ok(Budget {
             amount,
-            currency: "USD".to_string(),
+            currency: currency.to_string(),
             unit,
             span: Span::new(start, end),
         })

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -365,10 +365,46 @@ fn error_duplicate_budget() {
 }
 
 #[test]
-fn error_budget_missing_dollar() {
+fn parse_budget_euro() {
+    let f = parse_ok("agent bot { model: openai budget: €0.05 per request }");
+    let b = f.agents[0].budget.as_ref().unwrap();
+    assert_eq!(b.amount, 5);
+    assert_eq!(b.currency, "EUR");
+}
+
+#[test]
+fn parse_budget_pound() {
+    let f = parse_ok("agent bot { model: openai budget: £1.00 per ticket }");
+    let b = f.agents[0].budget.as_ref().unwrap();
+    assert_eq!(b.amount, 100);
+    assert_eq!(b.currency, "GBP");
+}
+
+#[test]
+fn parse_budget_yen() {
+    let f = parse_ok("agent bot { model: openai budget: ¥500 per run }");
+    let b = f.agents[0].budget.as_ref().unwrap();
+    assert_eq!(b.amount, 50000);
+    assert_eq!(b.currency, "JPY");
+}
+
+#[test]
+fn parse_capability_constraint_euro() {
+    let f = parse_ok("agent bot { model: openai can [stripe.refund up to €100] }");
+    let cap = &f.agents[0].can[0];
+    if let Some(crate::ast::Constraint::MonetaryCap { amount, currency }) = &cap.constraint {
+        assert_eq!(*amount, 10000);
+        assert_eq!(currency, "EUR");
+    } else {
+        panic!("expected MonetaryCap");
+    }
+}
+
+#[test]
+fn error_budget_missing_currency() {
     let err = parse_err("agent foo { budget: notadollar per ticket }");
     assert!(
-        err.message.to_lowercase().contains("dollar") || err.message.contains('$'),
+        err.message.contains("currency") || err.message.contains('$'),
         "got: {}",
         err.message
     );


### PR DESCRIPTION
Adds support for €, £, ¥ alongside existing $ in budgets and capability constraints.

## Changes

- **Lexer:** `Dollar(u64)` → `Currency { symbol: char, amount: u64 }`. Handles multi-byte UTF-8 currency symbols.
- **Parser:** Maps currency symbols to ISO codes (USD, EUR, GBP, JPY) in Budget and Constraint types.
- Fully backward compatible.

## Examples

```hcl
agent bot {
    model: openai
    budget: €0.10 per request
    can [stripe.refund up to £50]
}
```

## Tests

8 new tests. 315 total, all passing. Zero clippy warnings.