### PR TITLE
feat(parser): implement rich trigger expressions. Closes #143

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -586,8 +586,7 @@ impl Parser {
                     seen_trigger = true;
                     self.advance();
                     self.expect(&TokenKind::Colon)?;
-                    let (value, _) = self.expect_ident()?;
-                    trigger = Some(value);
+                    trigger = Some(self.parse_trigger_expr()?);
                 }
                 TokenKind::Stages => {
                     if seen_stages {
@@ -821,6 +820,35 @@ impl Parser {
             unit,
             span: Span::new(start, end),
         })
+    }
+    /// Parse a trigger expression: either a string literal or a sequence of
+    /// identifiers (e.g., `new ticket in zendesk`).
+    fn parse_trigger_expr(&mut self) -> Result<String, ParseError> {
+        self.skip_comments();
+        match self.peek().clone() {
+            TokenKind::StringLiteral(s) => {
+                self.advance();
+                Ok(s)
+            }
+            TokenKind::Ident(_) => {
+                let mut parts = Vec::new();
+                while let TokenKind::Ident(word) = self.peek().clone() {
+                    parts.push(word);
+                    self.advance();
+                }
+                if parts.is_empty() {
+                    return Err(ParseError::new(
+                        "expected trigger expression",
+                        self.current_span(),
+                    ));
+                }
+                Ok(parts.join(" "))
+            }
+            _ => Err(ParseError::new(
+                format!("expected trigger expression, got {}", self.peek()),
+                self.current_span(),
+            )),
+        }
     }
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -430,6 +430,48 @@ fn parse_workflow_stages_without_commas() {
 }
 
 #[test]
+fn parse_workflow_trigger_multi_word() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: new ticket in zendesk
+            stages: [a]
+        }
+    "#,
+    );
+    assert_eq!(f.workflows[0].trigger, "new ticket in zendesk");
+}
+
+#[test]
+fn parse_workflow_trigger_string_literal() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: "new message in channel"
+            stages: [a]
+        }
+    "#,
+    );
+    assert_eq!(f.workflows[0].trigger, "new message in channel");
+}
+
+#[test]
+fn parse_workflow_trigger_single_word() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: event
+            stages: [a]
+        }
+    "#,
+    );
+    assert_eq!(f.workflows[0].trigger, "event");
+}
+
+#[test]
 fn parse_workflow_missing_trigger_errors() {
     let err = parse_err(
         r#"


### PR DESCRIPTION
Triggers now accept multi-word expressions and string literals in addition to single identifiers.

## Examples

```hcl
workflow support {
    trigger: new ticket in zendesk    # multi-word
    trigger: "on new message"         # string literal
    trigger: event                     # single word (existing)
}
```

## Changes

- `parse_trigger_expr()`: consumes either a string literal or a sequence of idents joined by spaces
- Backward compatible with existing single-word triggers

## Tests

3 new tests. 310 total, all passing. Zero clippy warnings.