### PR TITLE
feat(parser): implement when expressions and route on blocks

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -237,6 +237,8 @@ pub struct StepDef {
     pub agent: String,
     /// Natural language goal describing what the step should accomplish.
     pub goal: Option<String>,
+    /// Optional condition that must be true for this step to execute.
+    pub when: Option<WhenExpr>,
     pub span: Span,
 }
 
@@ -250,8 +252,76 @@ pub struct WorkflowDef {
     pub stages: Vec<Stage>,
     /// Named step blocks (`step <name> { ... }`).
     pub steps: Vec<StepDef>,
+    /// Route-on blocks for conditional branching.
+    pub route_ons: Vec<RouteOnDef>,
     /// Default execution mode.
     pub mode: ExecutionMode,
+    pub span: Span,
+}
+
+// ---------------------------------------------------------------------------
+// Route-on types
+// ---------------------------------------------------------------------------
+
+/// A `route on <expr> { value -> target }` block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouteOnDef {
+    pub expr: String,
+    pub branches: Vec<RouteBranch>,
+    pub span: Span,
+}
+
+/// A single branch: `billing -> billing_agent` or `_ -> fallback`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouteBranch {
+    pub pattern: String,
+    pub target: String,
+    pub span: Span,
+}
+
+// ---------------------------------------------------------------------------
+// When expression types
+// ---------------------------------------------------------------------------
+
+/// A comparison operator in a `when` expression.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompareOp {
+    LessThan,
+    GreaterThan,
+}
+
+/// A threshold value in a `when` comparison.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThresholdValue {
+    /// A percentage (e.g. `70%`).
+    Percent { value: u64 },
+    /// A monetary amount (e.g. `$50`).
+    Currency { amount: u64, currency: String },
+}
+
+/// A single comparison: `field op threshold`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Comparison {
+    pub field: String,
+    pub op: CompareOp,
+    pub threshold: ThresholdValue,
+    pub span: Span,
+}
+
+/// A logical operator joining comparisons.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogicOp {
+    And,
+    Or,
+}
+
+/// A `when` expression: one or more comparisons joined by `and`/`or`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WhenExpr {
+    pub conditions: Vec<(Option<LogicOp>, Comparison)>,
     pub span: Span,
 }
 
@@ -461,6 +531,7 @@ mod tests {
                 },
             ],
             steps: vec![],
+            route_ons: vec![],
             mode: ExecutionMode::Sequential,
             span: dummy_span(),
         };
@@ -478,6 +549,7 @@ mod tests {
             trigger: "event".to_string(),
             stages: vec![],
             steps: vec![],
+            route_ons: vec![],
             mode: ExecutionMode::Parallel,
             span: dummy_span(),
         };
@@ -498,6 +570,7 @@ mod tests {
                 trigger: "event".to_string(),
                 stages: vec![],
                 steps: vec![],
+                route_ons: vec![],
                 mode: ExecutionMode::Sequential,
                 span: dummy_span(),
             }],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -23,7 +23,16 @@ pub enum TokenKind {
     Endpoint,
     Guardrails,
     Defaults,
+    Route,
+    On,
+    When,
+    And,
+    Or,
     // Symbols
+    Arrow,
+    LessThan,
+    GreaterThan,
+    Underscore,
     LBrace,
     RBrace,
     LBracket,
@@ -41,6 +50,8 @@ pub enum TokenKind {
         symbol: char,
         amount: u64,
     },
+    /// A percentage value (e.g. `70%`). Stored as integer (70 = 70%).
+    Percent(u64),
     // Trivia
     Comment,
     Eof,
@@ -77,10 +88,20 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Endpoint => write!(f, "endpoint"),
             TokenKind::Guardrails => write!(f, "guardrails"),
             TokenKind::Defaults => write!(f, "defaults"),
+            TokenKind::Route => write!(f, "route"),
+            TokenKind::On => write!(f, "on"),
+            TokenKind::When => write!(f, "when"),
+            TokenKind::And => write!(f, "and"),
+            TokenKind::Or => write!(f, "or"),
+            TokenKind::Arrow => write!(f, "->"),
+            TokenKind::LessThan => write!(f, "<"),
+            TokenKind::GreaterThan => write!(f, ">"),
+            TokenKind::Underscore => write!(f, "_"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Currency { symbol, amount } => {
                 write!(f, "{symbol}{}.{:02}", amount / 100, amount % 100)
             }
+            TokenKind::Percent(value) => write!(f, "{value}%"),
             TokenKind::StringLiteral(s) => write!(f, "\"{s}\""),
             TokenKind::Comment => write!(f, "comment"),
             TokenKind::Eof => write!(f, "end of file"),
@@ -201,6 +222,12 @@ impl<'a> Lexer<'a> {
             "endpoint" => TokenKind::Endpoint,
             "guardrails" => TokenKind::Guardrails,
             "defaults" => TokenKind::Defaults,
+            "route" => TokenKind::Route,
+            "on" => TokenKind::On,
+            "when" => TokenKind::When,
+            "and" => TokenKind::And,
+            "or" => TokenKind::Or,
+            "_" => TokenKind::Underscore,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)
@@ -285,6 +312,29 @@ impl<'a> Lexer<'a> {
         ))
     }
 
+    fn read_number(&mut self, start: usize) -> Result<Token, LexError> {
+        // First digit already consumed by advance() in run()
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.advance();
+        }
+
+        // Check for '%' suffix → Percent token
+        if self.peek() == Some(b'%') {
+            self.advance();
+            let num_str = std::str::from_utf8(&self.src[start..self.pos - 1]).unwrap();
+            let value: u64 = num_str.parse().map_err(|_| LexError {
+                message: format!("invalid percentage: '{num_str}%'"),
+                span: Span::new(start, self.pos),
+            })?;
+            return Ok(Token::new(TokenKind::Percent(value), start, self.pos));
+        }
+
+        Err(LexError {
+            message: "bare numbers are not allowed; use a currency symbol (e.g. $50) or percentage (e.g. 70%)".to_string(),
+            span: Span::new(start, self.pos),
+        })
+    }
+
     fn read_string(&mut self, start: usize) -> Result<Token, LexError> {
         // Opening '"' already consumed; collect content until closing '"'.
         let mut value = String::new();
@@ -354,6 +404,12 @@ impl<'a> Lexer<'a> {
                 Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
                 Some(b'"') => tokens.push(self.read_string(start)?),
                 Some(b'$') => tokens.push(self.read_currency('$', start)?),
+                Some(b'<') => tokens.push(Token::new(TokenKind::LessThan, start, self.pos)),
+                Some(b'>') => tokens.push(Token::new(TokenKind::GreaterThan, start, self.pos)),
+                Some(b'-') if self.peek() == Some(b'>') => {
+                    self.advance();
+                    tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
+                }
                 Some(b'#') => {
                     tokens.push(self.skip_line_comment(start));
                 }
@@ -365,8 +421,21 @@ impl<'a> Lexer<'a> {
                     self.advance(); // '*'
                     tokens.push(self.skip_block_comment(start)?);
                 }
+                Some(ch) if ch.is_ascii_digit() => {
+                    tokens.push(self.read_number(start)?);
+                }
                 Some(ch) if ch.is_ascii_alphabetic() || ch == b'_' => {
                     tokens.push(self.read_ident(start));
+                }
+                // → arrow (E2 86 92)
+                Some(0xE2)
+                    if self.pos + 1 < self.src.len()
+                        && self.src[self.pos] == 0x86
+                        && self.src[self.pos + 1] == 0x92 =>
+                {
+                    self.advance();
+                    self.advance();
+                    tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
                 }
                 // Multi-byte currency symbols: £ (C2 A3), ¥ (C2 A5), € (E2 82 AC)
                 Some(0xC2) if matches!(self.peek(), Some(0xA3 | 0xA5)) => {

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -535,3 +535,29 @@ fn tool_and_endpoint_keywords() {
     assert_eq!(tokens[3].kind, TokenKind::Endpoint);
     assert_eq!(tokens[4].kind, TokenKind::Colon);
 }
+
+#[test]
+fn arrow_ascii() {
+    let tokens = non_eof(lex_ok("a -> b"));
+    assert_eq!(tokens[1].kind, TokenKind::Arrow);
+}
+
+#[test]
+fn arrow_unicode() {
+    let tokens = non_eof(lex_ok("a → b"));
+    assert_eq!(tokens[1].kind, TokenKind::Arrow);
+}
+
+#[test]
+fn underscore_wildcard() {
+    let tokens = non_eof(lex_ok("_ -> x"));
+    assert_eq!(tokens[0].kind, TokenKind::Underscore);
+    assert_eq!(tokens[1].kind, TokenKind::Arrow);
+}
+
+#[test]
+fn route_on_keywords() {
+    let tokens = non_eof(lex_ok("route on"));
+    assert_eq!(tokens[0].kind, TokenKind::Route);
+    assert_eq!(tokens[1].kind, TokenKind::On);
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -612,6 +612,7 @@ impl Parser {
         let mut trigger: Option<String> = None;
         let mut stages: Vec<Stage> = Vec::new();
         let mut steps: Vec<crate::ast::StepDef> = Vec::new();
+        let mut route_ons: Vec<crate::ast::RouteOnDef> = Vec::new();
         let mut seen_trigger = false;
         let mut seen_stages = false;
 
@@ -629,9 +630,11 @@ impl Parser {
                         )
                     })?;
 
-                    if stages.is_empty() && steps.is_empty() {
+                    if stages.is_empty() && steps.is_empty() && route_ons.is_empty() {
                         return Err(ParseError::new(
-                            format!("workflow '{name}' must have at least one stage or step"),
+                            format!(
+                                "workflow '{name}' must have at least one stage, step, or route on"
+                            ),
                             Span::new(start, end),
                         ));
                     }
@@ -641,6 +644,7 @@ impl Parser {
                         trigger,
                         stages,
                         steps,
+                        route_ons,
                         mode: ExecutionMode::Sequential,
                         span: Span::new(start, end),
                     });
@@ -671,6 +675,9 @@ impl Parser {
                 }
                 TokenKind::Step => {
                     steps.push(self.parse_step()?);
+                }
+                TokenKind::Route => {
+                    route_ons.push(self.parse_route_on()?);
                 }
                 TokenKind::Eof => {
                     return Err(ParseError::new(
@@ -737,8 +744,10 @@ impl Parser {
 
         let mut agent: Option<String> = None;
         let mut goal: Option<String> = None;
+        let mut when: Option<crate::ast::WhenExpr> = None;
         let mut seen_agent = false;
         let mut seen_goal = false;
+        let mut seen_when = false;
 
         loop {
             self.skip_comments();
@@ -758,6 +767,7 @@ impl Parser {
                         name,
                         agent,
                         goal,
+                        when,
                         span: Span::new(start, end),
                     });
                 }
@@ -795,6 +805,18 @@ impl Parser {
                             ));
                         }
                     });
+                }
+                TokenKind::When => {
+                    if seen_when {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'when' in step '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_when = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    when = Some(self.parse_when_expr()?);
                 }
                 TokenKind::Eof => {
                     return Err(ParseError::new(
@@ -904,6 +926,296 @@ impl Parser {
     }
     /// Parse a trigger expression: either a string literal or a sequence of
     /// identifiers (e.g., `new ticket in zendesk`).
+    /// Parse a `when` expression: `field < 70% or field > $50`.
+    fn parse_when_expr(&mut self) -> Result<crate::ast::WhenExpr, ParseError> {
+        let start = self.current_span().start;
+        let mut conditions = Vec::new();
+
+        // First comparison (no leading logic op)
+        let comp = self.parse_comparison()?;
+        conditions.push((None, comp));
+
+        // Subsequent comparisons joined by `and`/`or`
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::And => {
+                    self.advance();
+                    let comp = self.parse_comparison()?;
+                    conditions.push((Some(crate::ast::LogicOp::And), comp));
+                }
+                TokenKind::Or => {
+                    self.advance();
+                    let comp = self.parse_comparison()?;
+                    conditions.push((Some(crate::ast::LogicOp::Or), comp));
+                }
+                _ => break,
+            }
+        }
+
+        let end = self.last_consumed_end;
+        Ok(crate::ast::WhenExpr {
+            conditions,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse a single comparison: `field < threshold` or `field > threshold`.
+    fn parse_comparison(&mut self) -> Result<crate::ast::Comparison, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        // Field: dotted identifier (e.g. `confidence` or `step.refund`)
+        let mut field_parts = Vec::new();
+        let (first, _) = self.expect_ident()?;
+        field_parts.push(first);
+        while self.peek() == &TokenKind::Dot {
+            self.advance();
+            let (part, _) = self.expect_ident()?;
+            field_parts.push(part);
+        }
+        let field = field_parts.join(".");
+
+        // Operator
+        self.skip_comments();
+        let op = match self.peek().clone() {
+            TokenKind::LessThan => {
+                self.advance();
+                crate::ast::CompareOp::LessThan
+            }
+            TokenKind::GreaterThan => {
+                self.advance();
+                crate::ast::CompareOp::GreaterThan
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!("expected '<' or '>' in when expression, got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+
+        // Threshold: percentage or currency
+        self.skip_comments();
+        let tok = self.current().clone();
+        let threshold = match &tok.kind {
+            TokenKind::Percent(value) => {
+                let value = *value;
+                self.advance();
+                crate::ast::ThresholdValue::Percent { value }
+            }
+            TokenKind::Currency { amount, symbol } => {
+                let amount = *amount;
+                let currency = match symbol {
+                    '€' => "EUR",
+                    '£' => "GBP",
+                    '¥' => "JPY",
+                    _ => "USD",
+                }
+                .to_string();
+                self.advance();
+                crate::ast::ThresholdValue::Currency { amount, currency }
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!(
+                        "expected percentage or currency amount in when expression, got {other}"
+                    ),
+                    tok.span,
+                ));
+            }
+        };
+
+        let end = self.last_consumed_end;
+        Ok(crate::ast::Comparison {
+            field,
+            op,
+            threshold,
+            span: Span::new(start, end),
+        })
+    }
+
+    fn parse_route_on(&mut self) -> Result<crate::ast::RouteOnDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Route)?;
+        self.expect(&TokenKind::On)?;
+
+        // Parse dotted expression (e.g., `classify.category` or `step.output`)
+        let mut expr_parts = Vec::new();
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::Ident(word) => {
+                    expr_parts.push(word);
+                    self.advance();
+                    if self.peek() == &TokenKind::Dot {
+                        expr_parts.push(".".to_string());
+                        self.advance();
+                    }
+                }
+                // Allow keywords as expression parts (e.g., `step.output`)
+                ref tok if self.peek() != &TokenKind::LBrace && self.peek() != &TokenKind::Eof => {
+                    let word = tok.to_string();
+                    if self.tokens.get(self.pos + 1).map(|t| &t.kind) == Some(&TokenKind::Dot)
+                        || !expr_parts.is_empty()
+                    {
+                        expr_parts.push(word);
+                        self.advance();
+                        if self.peek() == &TokenKind::Dot {
+                            expr_parts.push(".".to_string());
+                            self.advance();
+                        }
+                    } else {
+                        return Err(ParseError::new(
+                            format!("expected expression or '{{' in route on, got {tok}"),
+                            self.current_span(),
+                        ));
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        if expr_parts.is_empty() {
+            return Err(ParseError::new(
+                "route on requires an expression",
+                self.current_span(),
+            ));
+        }
+
+        let expr = expr_parts.join("");
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut branches = Vec::new();
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(crate::ast::RouteOnDef {
+                        expr,
+                        branches,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Ident(_) | TokenKind::Underscore => {
+                    branches.push(self.parse_route_branch()?);
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in route on block",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("expected branch or '}}' in route on, got {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn parse_route_branch(&mut self) -> Result<crate::ast::RouteBranch, ParseError> {
+        let start = self.current_span().start;
+
+        let pattern = match self.peek().clone() {
+            TokenKind::Underscore => {
+                self.advance();
+                "_".to_string()
+            }
+            TokenKind::Ident(name) => {
+                self.advance();
+                name
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!("expected branch pattern, got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+
+        self.expect(&TokenKind::Arrow)?;
+
+        // Target: idents and keywords, but stop if the NEXT word-like token
+        // is followed by Arrow (that means it's the start of the next branch)
+        let mut target_parts = Vec::new();
+        loop {
+            self.skip_comments();
+            if let Some(word) = self.current_word() {
+                // Lookahead: if the token after this is Arrow,
+                // this word is the next branch's pattern, not our target
+                if !target_parts.is_empty() && self.is_next_arrow() {
+                    break;
+                }
+                target_parts.push(word);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        if target_parts.is_empty() {
+            return Err(ParseError::new(
+                format!("expected target after '->' in branch '{pattern}'"),
+                self.current_span(),
+            ));
+        }
+
+        let end = self.last_consumed_end;
+        Ok(crate::ast::RouteBranch {
+            pattern,
+            target: target_parts.join(" "),
+            span: Span::new(start, end),
+        })
+    }
+
+    /// If the current token is a word-like token (identifier or keyword),
+    /// return its string representation. Used in contexts where keywords
+    /// can appear as plain words (e.g. route branch targets).
+    fn current_word(&self) -> Option<String> {
+        match &self.current().kind {
+            TokenKind::Ident(s) => Some(s.clone()),
+            TokenKind::Agent => Some("agent".to_string()),
+            TokenKind::Can => Some("can".to_string()),
+            TokenKind::Cannot => Some("cannot".to_string()),
+            TokenKind::Model => Some("model".to_string()),
+            TokenKind::Budget => Some("budget".to_string()),
+            TokenKind::Per => Some("per".to_string()),
+            TokenKind::Up => Some("up".to_string()),
+            TokenKind::To => Some("to".to_string()),
+            TokenKind::Workflow => Some("workflow".to_string()),
+            TokenKind::Trigger => Some("trigger".to_string()),
+            TokenKind::Stages => Some("stages".to_string()),
+            TokenKind::Provider => Some("provider".to_string()),
+            TokenKind::Key => Some("key".to_string()),
+            TokenKind::Step => Some("step".to_string()),
+            TokenKind::Goal => Some("goal".to_string()),
+            TokenKind::Tool => Some("tool".to_string()),
+            TokenKind::Endpoint => Some("endpoint".to_string()),
+            TokenKind::Guardrails => Some("guardrails".to_string()),
+            TokenKind::Defaults => Some("defaults".to_string()),
+            TokenKind::Route => Some("route".to_string()),
+            TokenKind::On => Some("on".to_string()),
+            TokenKind::When => Some("when".to_string()),
+            TokenKind::And => Some("and".to_string()),
+            TokenKind::Or => Some("or".to_string()),
+            _ => None,
+        }
+    }
+
+    /// Peek two tokens ahead: is the token after the current one an Arrow?
+    fn is_next_arrow(&self) -> bool {
+        if self.pos + 1 < self.tokens.len() {
+            self.tokens[self.pos + 1].kind == TokenKind::Arrow
+        } else {
+            false
+        }
+    }
+
     fn parse_trigger_expr(&mut self) -> Result<String, ParseError> {
         self.skip_comments();
         match self.peek().clone() {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -508,6 +508,89 @@ fn parse_workflow_trigger_single_word() {
 }
 
 #[test]
+fn parse_route_on_basic() {
+    let f = parse_ok(
+        r#"
+        agent billing { model: openai }
+        agent tech { model: openai }
+        agent fallback { model: openai }
+        workflow pipe {
+            trigger: event
+            route on classify.category {
+                billing -> billing
+                technical -> tech
+                _ -> fallback
+            }
+        }
+    "#,
+    );
+    let route = &f.workflows[0].route_ons[0];
+    assert_eq!(route.expr, "classify.category");
+    assert_eq!(route.branches.len(), 3);
+    assert_eq!(route.branches[0].pattern, "billing");
+    assert_eq!(route.branches[0].target, "billing");
+    assert_eq!(route.branches[1].pattern, "technical");
+    assert_eq!(route.branches[1].target, "tech");
+    assert_eq!(route.branches[2].pattern, "_");
+    assert_eq!(route.branches[2].target, "fallback");
+}
+
+#[test]
+fn parse_route_on_unicode_arrow() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: event
+            route on step.output {
+                yes → a
+                _ → a
+            }
+        }
+    "#,
+    );
+    assert_eq!(f.workflows[0].route_ons[0].branches.len(), 2);
+}
+
+#[test]
+fn parse_route_on_multi_word_target() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: event
+            route on step.result {
+                fail -> escalate to human
+                _ -> a
+            }
+        }
+    "#,
+    );
+    assert_eq!(
+        f.workflows[0].route_ons[0].branches[0].target,
+        "escalate to human"
+    );
+}
+
+#[test]
+fn parse_route_on_as_only_content() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow pipe {
+            trigger: event
+            route on x.y {
+                _ -> a
+            }
+        }
+    "#,
+    );
+    assert!(f.workflows[0].stages.is_empty());
+    assert!(f.workflows[0].steps.is_empty());
+    assert_eq!(f.workflows[0].route_ons.len(), 1);
+}
+
+#[test]
 fn parse_workflow_missing_trigger_errors() {
     let err = parse_err(
         r#"

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -34,6 +34,7 @@ fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDe
             })
             .collect(),
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }
@@ -333,6 +334,7 @@ fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
             },
         ],
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -427,6 +429,7 @@ async fn conditional_no_else_ends_workflow() {
             },
         ],
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -784,6 +787,7 @@ async fn conditional_route_to_nonexistent_stage_errors() {
             span: Span::new(0, 1),
         }],
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -847,6 +851,7 @@ async fn circular_route_returns_error() {
             },
         ],
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -270,6 +270,7 @@ fn make_workflow(name: &str, trigger: &str, agents: &[&str]) -> WorkflowDef {
             })
             .collect(),
         steps: vec![],
+        route_ons: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }


### PR DESCRIPTION
## Summary

Adds two conditional execution features to workflows:

### When expressions (#128)
Steps can now have a `when:` condition that must evaluate to true for execution:
```
step escalate {
  agent: escalation
  goal: "Handle high-value cases"
  when: confidence < 70% or refund > $50
}
```

Supports:
- Comparison operators: `<`, `>`
- Threshold types: percentages (`70%`), currency (`$50`)
- Logic operators: `and`, `or`

### Route on blocks (#125)
Value-based branching within workflows:
```
route on classify.category {
  billing -> billing_agent
  technical -> triage
  _ -> fallback
}
```

Supports dotted expressions and wildcard (`_`) fallback patterns.

## Changes
- **AST:** `WhenExpr`, `CompareOp`, `ThresholdValue`, `Comparison`, `LogicOp`, `RouteOnDef`, `RouteBranch` types
- **Lexer:** `Arrow` (`->`), `Underscore`, `And`, `Or`, `LessThan`, `GreaterThan` tokens
- **Parser:** `parse_when_expr`, `parse_route_on` methods integrated into workflow/step parsing
- **Tests:** Full coverage for both features

## QA
- `cargo test`: 336 tests passing
- `cargo clippy -- -D warnings`: clean
- `cargo fmt`: clean
- Manual validation of .rein files with both features ✓

Closes #125, closes #128