### PR TITLE
feat(parser): implement inline parallel blocks in workflows

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -240,6 +240,13 @@ pub struct StepDef {
     pub span: Span,
 }
 
+/// A parallel group of steps: `parallel { step a {...} step b {...} }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParallelBlock {
+    pub steps: Vec<StepDef>,
+    pub span: Span,
+}
+
 /// A `workflow <name> { ... }` definition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkflowDef {
@@ -250,6 +257,8 @@ pub struct WorkflowDef {
     pub stages: Vec<Stage>,
     /// Named step blocks (`step <name> { ... }`).
     pub steps: Vec<StepDef>,
+    /// Inline parallel blocks containing grouped steps.
+    pub parallel_blocks: Vec<ParallelBlock>,
     /// Default execution mode.
     pub mode: ExecutionMode,
     pub span: Span,
@@ -461,6 +470,7 @@ mod tests {
                 },
             ],
             steps: vec![],
+            parallel_blocks: vec![],
             mode: ExecutionMode::Sequential,
             span: dummy_span(),
         };
@@ -478,6 +488,7 @@ mod tests {
             trigger: "event".to_string(),
             stages: vec![],
             steps: vec![],
+            parallel_blocks: vec![],
             mode: ExecutionMode::Parallel,
             span: dummy_span(),
         };
@@ -498,6 +509,7 @@ mod tests {
                 trigger: "event".to_string(),
                 stages: vec![],
                 steps: vec![],
+                parallel_blocks: vec![],
                 mode: ExecutionMode::Sequential,
                 span: dummy_span(),
             }],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -23,6 +23,7 @@ pub enum TokenKind {
     Endpoint,
     Guardrails,
     Defaults,
+    Parallel,
     // Symbols
     LBrace,
     RBrace,
@@ -77,6 +78,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Endpoint => write!(f, "endpoint"),
             TokenKind::Guardrails => write!(f, "guardrails"),
             TokenKind::Defaults => write!(f, "defaults"),
+            TokenKind::Parallel => write!(f, "parallel"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Currency { symbol, amount } => {
                 write!(f, "{symbol}{}.{:02}", amount / 100, amount % 100)
@@ -201,6 +203,7 @@ impl<'a> Lexer<'a> {
             "endpoint" => TokenKind::Endpoint,
             "guardrails" => TokenKind::Guardrails,
             "defaults" => TokenKind::Defaults,
+            "parallel" => TokenKind::Parallel,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -535,3 +535,14 @@ fn tool_and_endpoint_keywords() {
     assert_eq!(tokens[3].kind, TokenKind::Endpoint);
     assert_eq!(tokens[4].kind, TokenKind::Colon);
 }
+
+// ── Parallel keyword test ────────────────────────────────────────────────
+
+#[test]
+fn tokenize_parallel_keyword() {
+    let tokens = non_eof(lex_ok("parallel { step }"));
+    assert_eq!(tokens[0].kind, TokenKind::Parallel);
+    assert_eq!(tokens[1].kind, TokenKind::LBrace);
+    assert_eq!(tokens[2].kind, TokenKind::Step);
+    assert_eq!(tokens[3].kind, TokenKind::RBrace);
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -612,6 +612,7 @@ impl Parser {
         let mut trigger: Option<String> = None;
         let mut stages: Vec<Stage> = Vec::new();
         let mut steps: Vec<crate::ast::StepDef> = Vec::new();
+        let mut parallel_blocks: Vec<crate::ast::ParallelBlock> = Vec::new();
         let mut seen_trigger = false;
         let mut seen_stages = false;
 
@@ -629,7 +630,7 @@ impl Parser {
                         )
                     })?;
 
-                    if stages.is_empty() && steps.is_empty() {
+                    if stages.is_empty() && steps.is_empty() && parallel_blocks.is_empty() {
                         return Err(ParseError::new(
                             format!("workflow '{name}' must have at least one stage or step"),
                             Span::new(start, end),
@@ -641,6 +642,7 @@ impl Parser {
                         trigger,
                         stages,
                         steps,
+                        parallel_blocks,
                         mode: ExecutionMode::Sequential,
                         span: Span::new(start, end),
                     });
@@ -668,6 +670,9 @@ impl Parser {
                     self.advance();
                     self.expect(&TokenKind::Colon)?;
                     stages = self.parse_stage_list()?;
+                }
+                TokenKind::Parallel => {
+                    parallel_blocks.push(self.parse_parallel_block()?);
                 }
                 TokenKind::Step => {
                     steps.push(self.parse_step()?);
@@ -727,6 +732,52 @@ impl Parser {
     }
 
     /// Parse a `step <name> { agent: <ident> goal: <text> }` block.
+    fn parse_parallel_block(&mut self) -> Result<crate::ast::ParallelBlock, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Parallel)?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut steps = Vec::new();
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+
+                    if steps.is_empty() {
+                        return Err(ParseError::new(
+                            "parallel block must contain at least one step",
+                            Span::new(start, end),
+                        ));
+                    }
+
+                    return Ok(crate::ast::ParallelBlock {
+                        steps,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Step => {
+                    steps.push(self.parse_step()?);
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in parallel block",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("expected step or }} in parallel block, got {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
     fn parse_step(&mut self) -> Result<crate::ast::StepDef, ParseError> {
         self.skip_comments();
         let start = self.current_span().start;

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1032,3 +1032,104 @@ fn parse_multiple_tools() {
     );
     assert_eq!(f.tools.len(), 2);
 }
+
+// ── Inline parallel block tests ──────────────────────────────────────────
+
+#[test]
+fn parse_parallel_block_with_two_steps() {
+    let f = parse_ok(
+        r#"
+        agent bot {
+            model: anthropic
+            can [tools.read]
+            budget: $1 per request
+        }
+
+        workflow flow {
+            trigger: event
+            parallel {
+                step a { agent: bot goal: "do A" }
+                step b { agent: bot goal: "do B" }
+            }
+        }
+    "#,
+    );
+    let wf = &f.workflows[0];
+    assert_eq!(wf.parallel_blocks.len(), 1);
+    assert_eq!(wf.parallel_blocks[0].steps.len(), 2);
+    assert_eq!(wf.parallel_blocks[0].steps[0].name, "a");
+    assert_eq!(wf.parallel_blocks[0].steps[1].name, "b");
+}
+
+#[test]
+fn parse_parallel_block_mixed_with_regular_steps() {
+    let f = parse_ok(
+        r#"
+        agent bot {
+            model: anthropic
+            can [tools.read]
+            budget: $1 per request
+        }
+
+        workflow flow {
+            trigger: event
+            step first { agent: bot goal: "first" }
+            parallel {
+                step a { agent: bot goal: "do A" }
+                step b { agent: bot goal: "do B" }
+            }
+            step last { agent: bot goal: "last" }
+        }
+    "#,
+    );
+    let wf = &f.workflows[0];
+    assert_eq!(wf.steps.len(), 2);
+    assert_eq!(wf.parallel_blocks.len(), 1);
+    assert_eq!(wf.parallel_blocks[0].steps.len(), 2);
+}
+
+#[test]
+fn parse_multiple_parallel_blocks() {
+    let f = parse_ok(
+        r#"
+        agent bot {
+            model: anthropic
+            can [tools.read]
+            budget: $1 per request
+        }
+
+        workflow flow {
+            trigger: event
+            parallel {
+                step a { agent: bot goal: "A" }
+                step b { agent: bot goal: "B" }
+            }
+            parallel {
+                step c { agent: bot goal: "C" }
+                step d { agent: bot goal: "D" }
+            }
+        }
+    "#,
+    );
+    let wf = &f.workflows[0];
+    assert_eq!(wf.parallel_blocks.len(), 2);
+    assert_eq!(wf.parallel_blocks[0].steps.len(), 2);
+    assert_eq!(wf.parallel_blocks[1].steps.len(), 2);
+}
+
+#[test]
+fn parse_parallel_block_empty_fails() {
+    let src = r#"
+        agent bot {
+            model: anthropic
+            can [tools.read]
+            budget: $1 per request
+        }
+        workflow flow {
+            trigger: event
+            parallel {}
+        }
+    "#;
+    let result = crate::parser::parse(src);
+    assert!(result.is_err());
+}

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -34,6 +34,7 @@ fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDe
             })
             .collect(),
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }
@@ -333,6 +334,7 @@ fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
             },
         ],
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -427,6 +429,7 @@ async fn conditional_no_else_ends_workflow() {
             },
         ],
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -784,6 +787,7 @@ async fn conditional_route_to_nonexistent_stage_errors() {
             span: Span::new(0, 1),
         }],
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -847,6 +851,7 @@ async fn circular_route_returns_error() {
             },
         ],
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -270,6 +270,7 @@ fn make_workflow(name: &str, trigger: &str, agents: &[&str]) -> WorkflowDef {
             })
             .collect(),
         steps: vec![],
+        parallel_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }


### PR DESCRIPTION
## Summary

Adds inline `parallel { ... }` blocks within workflows for concurrent step execution (#126).

### Syntax
```
workflow pipeline {
  trigger: new_data
  step preprocess { agent: fetcher goal: "Prepare data" }
  parallel {
    step fetch_a { agent: fetcher goal: "Fetch source A" }
    step fetch_b { agent: fetcher goal: "Fetch source B" }
  }
  step combine { agent: analyzer goal: "Combine results" }
}
```

### Changes
- **AST:** `ParallelBlock { steps, span }`, `parallel_blocks` field on `WorkflowDef`
- **Lexer:** `Parallel` keyword token
- **Parser:** `parse_parallel_block` method with empty-block validation
- Multiple parallel blocks allowed, can mix with regular steps

### Tests
- 1 lexer test, 4 parser tests (two steps, mixed with regular, multiple blocks, empty-fails)

### QA
- `cargo test`: 333 tests passing
- `cargo clippy -- -D warnings`: clean
- `cargo fmt`: clean
- Manual `rein validate` ✓

Closes #126