### PR TITLE
feat(workflow): extensible condition matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dotenvy",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 dotenvy = "0.15"
 async-trait = "0.1.89"
+regex = "1.12.3"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -194,6 +194,23 @@ pub struct ToolDef {
 // Workflow types
 // ---------------------------------------------------------------------------
 
+/// How a condition is evaluated against agent output.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "mode", content = "value", rename_all = "snake_case")]
+pub enum ConditionMatcher {
+    /// Exact value match (case-insensitive, word-boundary aware).
+    Equals(String),
+    /// Substring containment (case-insensitive).
+    Contains(String),
+    /// Regular expression match.
+    Regex(String),
+    /// JSON path extraction and comparison (`path=expected`).
+    JsonPath {
+        path: String,
+        expected: String,
+    },
+}
+
 /// How a workflow stage routes to the next stage.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -203,7 +220,7 @@ pub enum RouteRule {
     /// Route based on a condition in the agent's output.
     Conditional {
         field: String,
-        equals: String,
+        matcher: ConditionMatcher,
         then_stage: String,
         else_stage: Option<String>,
     },
@@ -438,7 +455,7 @@ mod tests {
     fn conditional_route_serializes() {
         let route = RouteRule::Conditional {
             field: "sentiment".to_string(),
-            equals: "negative".to_string(),
+            matcher: ConditionMatcher::Equals("negative".to_string()),
             then_stage: "escalate".to_string(),
             else_stage: Some("respond".to_string()),
         };

--- a/src/runtime/workflow/condition.rs
+++ b/src/runtime/workflow/condition.rs
@@ -1,0 +1,84 @@
+//! Condition matching for workflow routing.
+//!
+//! Supports multiple matching strategies: exact equality, substring containment,
+//! regular expressions, and JSON path extraction.
+
+use crate::ast::ConditionMatcher;
+
+/// Extract the value of a `field: value` or `field=value` line from output.
+fn extract_field_value<'a>(output: &'a str, field: &str) -> Option<&'a str> {
+    let field_lower = field.to_lowercase();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        let lower = trimmed.to_lowercase();
+        if let Some(rest) = lower.strip_prefix(&field_lower) {
+            let rest = rest.trim_start();
+            if rest.starts_with(':') || rest.starts_with('=') {
+                // Return from original (non-lowered) trimmed line
+                let offset = trimmed.len() - rest.len() + 1; // skip ':' or '='
+                return Some(trimmed[offset..].trim());
+            }
+        }
+    }
+    None
+}
+
+/// Check whether a conditional route matches the agent output.
+///
+/// Supports multiple matching strategies via [`ConditionMatcher`].
+pub fn condition_matches(output: &str, field: &str, matcher: &ConditionMatcher) -> bool {
+    match matcher {
+        ConditionMatcher::Equals(expected) => {
+            let Some(val) = extract_field_value(output, field) else {
+                return false;
+            };
+            let val_lower = val.to_lowercase();
+            let expected_lower = expected.to_lowercase();
+            val_lower == expected_lower
+                || val_lower.strip_prefix(&expected_lower).is_some_and(|rest| {
+                    rest.starts_with(|c: char| !c.is_alphanumeric() && c != '_')
+                })
+        }
+        ConditionMatcher::Contains(needle) => {
+            let Some(val) = extract_field_value(output, field) else {
+                return false;
+            };
+            val.to_lowercase().contains(&needle.to_lowercase())
+        }
+        ConditionMatcher::Regex(pattern) => {
+            let Some(val) = extract_field_value(output, field) else {
+                return false;
+            };
+            regex::Regex::new(pattern)
+                .map(|re| re.is_match(val))
+                .unwrap_or(false)
+        }
+        ConditionMatcher::JsonPath { path, expected } => json_path_matches(output, path, expected),
+    }
+}
+
+/// Match a JSON path expression against output parsed as JSON.
+fn json_path_matches(output: &str, path: &str, expected: &str) -> bool {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output) else {
+        return false;
+    };
+    let value = resolve_json_path(&parsed, path);
+    match value {
+        Some(serde_json::Value::String(s)) => s.eq_ignore_ascii_case(expected),
+        Some(serde_json::Value::Number(n)) => n.to_string() == expected,
+        Some(serde_json::Value::Bool(b)) => b.to_string() == expected,
+        _ => false,
+    }
+}
+
+/// Resolve a dot-separated JSON path (e.g. `result.status`) against a value.
+fn resolve_json_path<'a>(
+    value: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -5,7 +5,10 @@ use super::executor::ToolExecutor;
 use super::permissions::ToolRegistry;
 use super::provider::{Provider, ToolDef};
 
+mod condition;
 pub mod persistence;
+
+use condition::condition_matches;
 
 #[cfg(test)]
 mod tests;
@@ -131,37 +134,6 @@ fn build_result(stage_results: Vec<StageResult>, final_output: String) -> Workfl
     }
 }
 
-/// Check whether a conditional route matches the agent output.
-///
-/// Looks for `field: value` or `field=value` patterns in the output text.
-/// Uses exact value matching (not prefix) to avoid false positives like
-/// "high" matching "higher".
-fn condition_matches(output: &str, field: &str, equals: &str) -> bool {
-    let lower = output.to_lowercase();
-    let field_lower = field.to_lowercase();
-    let equals_lower = equals.to_lowercase();
-
-    for line in lower.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix(&field_lower) {
-            let rest = rest.trim_start();
-            if let Some(val) = rest.strip_prefix(':').or_else(|| rest.strip_prefix('=')) {
-                let val = val.trim();
-                // Exact match: the value equals our target, or is followed
-                // by a non-alphanumeric character (e.g. "high." or "high,")
-                if val == equals_lower
-                    || val.strip_prefix(equals_lower.as_str()).is_some_and(|rest| {
-                        rest.starts_with(|c: char| !c.is_alphanumeric() && c != '_')
-                    })
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-
 /// Resolve the next stage given the current stage's route rule and output.
 ///
 /// This is the single source of truth for routing logic, used by both
@@ -178,11 +150,11 @@ fn resolve_next_stage<'a>(
         }
         RouteRule::Conditional {
             field,
-            equals,
+            matcher,
             then_stage,
             else_stage,
         } => {
-            if condition_matches(output, field, equals) {
+            if condition_matches(output, field, matcher) {
                 Ok(Some(workflow.find_stage(then_stage).ok_or_else(|| {
                     WorkflowError::StageNotFound(then_stage.clone())
                 })?))

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ast::{ExecutionMode, RouteRule, Span, Stage, WorkflowDef};
+use crate::ast::{ConditionMatcher, ExecutionMode, RouteRule, Span, Stage, WorkflowDef};
 use crate::runtime::executor::MockExecutor;
 use crate::runtime::provider::{ChatResponse, MockProvider, Usage};
 use tempfile::NamedTempFile;
@@ -333,7 +333,7 @@ fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
                 agent: "triage".to_string(),
                 route: RouteRule::Conditional {
                     field: "priority".to_string(),
-                    equals: "high".to_string(),
+                    matcher: ConditionMatcher::Equals("high".to_string()),
                     then_stage: "escalate".to_string(),
                     else_stage: Some("respond".to_string()),
                 },
@@ -439,7 +439,7 @@ async fn conditional_no_else_ends_workflow() {
                 agent: "checker".to_string(),
                 route: RouteRule::Conditional {
                     field: "needs_action".to_string(),
-                    equals: "yes".to_string(),
+                    matcher: ConditionMatcher::Equals("yes".to_string()),
                     then_stage: "handler".to_string(),
                     else_stage: None,
                 },
@@ -801,15 +801,61 @@ async fn resumable_corrupt_checkpoint_returns_persistence_error() {
 
 #[tokio::test]
 async fn condition_match_rejects_prefix_false_positive() {
+    let eq_high = ConditionMatcher::Equals("high".to_string());
     // "high" should NOT match "higher"
-    assert!(condition_matches("priority: high", "priority", "high"));
-    assert!(condition_matches("priority: high.", "priority", "high"));
-    assert!(!condition_matches("priority: higher", "priority", "high"));
+    assert!(condition_matches("priority: high", "priority", &eq_high));
+    assert!(condition_matches("priority: high.", "priority", &eq_high));
+    assert!(!condition_matches("priority: higher", "priority", &eq_high));
     assert!(!condition_matches(
         "priority: highlights",
         "priority",
-        "high"
+        &eq_high,
     ));
+
+    // Contains matcher
+    let contains = ConditionMatcher::Contains("bill".to_string());
+    assert!(condition_matches("category: billing issue", "category", &contains));
+    assert!(!condition_matches("category: technical", "category", &contains));
+
+    // Regex matcher
+    let regex = ConditionMatcher::Regex(r"^(high|critical)$".to_string());
+    assert!(condition_matches("priority: high", "priority", &regex));
+    assert!(condition_matches("priority: critical", "priority", &regex));
+    assert!(!condition_matches("priority: low", "priority", &regex));
+
+    // Invalid regex doesn't panic, just returns false
+    let bad_regex = ConditionMatcher::Regex(r"[invalid".to_string());
+    assert!(!condition_matches("priority: high", "priority", &bad_regex));
+}
+
+#[tokio::test]
+async fn condition_match_json_path() {
+    let json_output = r#"{"result": {"status": "escalated", "score": 95}}"#;
+
+    let jp = ConditionMatcher::JsonPath {
+        path: "result.status".to_string(),
+        expected: "escalated".to_string(),
+    };
+    assert!(condition_matches(json_output, "", &jp));
+
+    let jp_num = ConditionMatcher::JsonPath {
+        path: "result.score".to_string(),
+        expected: "95".to_string(),
+    };
+    assert!(condition_matches(json_output, "", &jp_num));
+
+    let jp_miss = ConditionMatcher::JsonPath {
+        path: "result.status".to_string(),
+        expected: "resolved".to_string(),
+    };
+    assert!(!condition_matches(json_output, "", &jp_miss));
+
+    // Non-JSON output returns false
+    let jp2 = ConditionMatcher::JsonPath {
+        path: "status".to_string(),
+        expected: "ok".to_string(),
+    };
+    assert!(!condition_matches("not json at all", "", &jp2));
 }
 
 #[tokio::test]
@@ -828,7 +874,7 @@ async fn conditional_route_to_nonexistent_stage_errors() {
             agent: "triage".to_string(),
             route: RouteRule::Conditional {
                 field: "priority".to_string(),
-                equals: "high".to_string(),
+                matcher: ConditionMatcher::Equals("high".to_string()),
                 then_stage: "nonexistent".to_string(),
                 else_stage: None,
             },
@@ -882,7 +928,7 @@ async fn circular_route_returns_error() {
                 agent: "a".to_string(),
                 route: RouteRule::Conditional {
                     field: "go".to_string(),
-                    equals: "yes".to_string(),
+                    matcher: ConditionMatcher::Equals("yes".to_string()),
                     then_stage: "b".to_string(),
                     else_stage: None,
                 },
@@ -893,7 +939,7 @@ async fn circular_route_returns_error() {
                 agent: "b".to_string(),
                 route: RouteRule::Conditional {
                     field: "go".to_string(),
-                    equals: "yes".to_string(),
+                    matcher: ConditionMatcher::Equals("yes".to_string()),
                     then_stage: "a".to_string(),
                     else_stage: None,
                 },


### PR DESCRIPTION
Closes #88

Introduces `ConditionMatcher` enum with four matching strategies:
- **Equals**: existing exact match (case-insensitive, word-boundary aware)
- **Contains**: substring containment
- **Regex**: regular expression matching
- **JsonPath**: dot-separated path extraction from JSON output

Extracted condition logic into `condition.rs` module to keep `mod.rs` under 400 lines.