### PR TITLE
feat(types): type system with built-ins, arrays, and ranges

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -198,11 +198,34 @@ pub struct ToolDef {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TypeExpr {
+    /// A built-in or user-defined named type (e.g. `string`, `int`, `MyType`).
+    Named { name: String, array: bool },
     /// A union of allowed values: `one of [billing, technical, general]`.
     OneOf {
         variants: Vec<String>,
         span: Span,
     },
+    /// A numeric range: `1..10` or `0.0..1.0`.
+    Range {
+        min: String,
+        max: String,
+    },
+}
+
+/// A field within a `type` definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TypeField {
+    pub name: String,
+    pub type_expr: TypeExpr,
+    pub span: Span,
+}
+
+/// A `type Name { ... }` definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TypeDef {
+    pub name: String,
+    pub fields: Vec<TypeField>,
+    pub span: Span,
 }
 
 /// How a condition is evaluated against agent output.
@@ -304,6 +327,7 @@ pub struct ReinFile {
     pub tools: Vec<ToolDef>,
     pub agents: Vec<AgentDef>,
     pub workflows: Vec<WorkflowDef>,
+    pub types: Vec<TypeDef>,
 }
 
 #[cfg(test)]
@@ -426,6 +450,7 @@ mod tests {
                 span: dummy_span(),
             }],
             workflows: vec![],
+            types: vec![],
         };
         let json = serde_json::to_string(&file).unwrap();
         let decoded: ReinFile = serde_json::from_str(&json).unwrap();
@@ -538,6 +563,7 @@ mod tests {
                 mode: ExecutionMode::Sequential,
                 span: dummy_span(),
             }],
+            types: vec![],
         };
         let json = serde_json::to_string(&file).unwrap();
         let decoded: ReinFile = serde_json::from_str(&json).unwrap();

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -25,6 +25,7 @@ pub enum TokenKind {
     Defaults,
     One,
     Of,
+    Type,
     // Symbols
     LBrace,
     RBrace,
@@ -34,10 +35,13 @@ pub enum TokenKind {
     RParen,
     Colon,
     Dot,
+    DotDot,
     Comma,
     // Literals
     Ident(String),
     StringLiteral(String),
+    /// A numeric literal (integer or float, stored as string for flexibility).
+    Number(String),
     /// A monetary amount with currency symbol and value in minor units (cents).
     Currency {
         symbol: char,
@@ -81,6 +85,9 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Defaults => write!(f, "defaults"),
             TokenKind::One => write!(f, "one"),
             TokenKind::Of => write!(f, "of"),
+            TokenKind::Type => write!(f, "type"),
+            TokenKind::DotDot => write!(f, ".."),
+            TokenKind::Number(n) => write!(f, "{n}"),
             TokenKind::Ident(s) => write!(f, "{s}"),
             TokenKind::Currency { symbol, amount } => {
                 write!(f, "{symbol}{}.{:02}", amount / 100, amount % 100)
@@ -207,9 +214,26 @@ impl<'a> Lexer<'a> {
             "defaults" => TokenKind::Defaults,
             "one" => TokenKind::One,
             "of" => TokenKind::Of,
+            "type" => TokenKind::Type,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)
+    }
+
+    fn read_number(&mut self, start: usize) -> Token {
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.advance();
+        }
+        // Optional decimal part
+        if self.peek() == Some(b'.') && self.peek_at(1).is_some_and(|b| b.is_ascii_digit()) {
+            self.advance(); // consume '.'
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.advance();
+            }
+        }
+        let end = self.pos;
+        let text = std::str::from_utf8(&self.src[start..end]).unwrap().to_string();
+        Token::new(TokenKind::Number(text), start, end)
     }
 
     fn read_currency(&mut self, symbol: char, start: usize) -> Result<Token, LexError> {
@@ -356,7 +380,14 @@ impl<'a> Lexer<'a> {
                 Some(b'(') => tokens.push(Token::new(TokenKind::LParen, start, self.pos)),
                 Some(b')') => tokens.push(Token::new(TokenKind::RParen, start, self.pos)),
                 Some(b':') => tokens.push(Token::new(TokenKind::Colon, start, self.pos)),
-                Some(b'.') => tokens.push(Token::new(TokenKind::Dot, start, self.pos)),
+                Some(b'.') => {
+                    if self.peek() == Some(b'.') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::DotDot, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Dot, start, self.pos));
+                    }
+                }
                 Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
                 Some(b'"') => tokens.push(self.read_string(start)?),
                 Some(b'$') => tokens.push(self.read_currency('$', start)?),
@@ -370,6 +401,9 @@ impl<'a> Lexer<'a> {
                 Some(b'/') if self.peek() == Some(b'*') => {
                     self.advance(); // '*'
                     tokens.push(self.skip_block_comment(start)?);
+                }
+                Some(ch) if ch.is_ascii_digit() => {
+                    tokens.push(self.read_number(start));
                 }
                 Some(ch) if ch.is_ascii_alphabetic() || ch == b'_' => {
                     tokens.push(self.read_ident(start));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+
 pub mod ast;
 pub mod config;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+
 mod commands;
 
 use clap::{Parser, Subcommand};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,8 @@
 use crate::ast::{
     AgentDef, Budget, Capability, Constraint, DefaultsDef, ExecutionMode, GuardrailRule,
     GuardrailSection, GuardrailsDef, ProviderDef, ReinFile, RouteRule, Span, Stage, ToolDef,
-    TypeExpr, ValueExpr, WorkflowDef,
+    TypeDef, TypeExpr, TypeField, ValueExpr, WorkflowDef,
+
 };
 use crate::lexer::{Token, TokenKind, tokenize};
 
@@ -196,6 +197,7 @@ impl Parser {
         let mut tools = Vec::new();
         let mut agents = Vec::new();
         let mut workflows = Vec::new();
+        let mut types = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
                 TokenKind::Defaults => {
@@ -211,10 +213,11 @@ impl Parser {
                 TokenKind::Tool => tools.push(self.parse_tool()?),
                 TokenKind::Agent => agents.push(self.parse_agent()?),
                 TokenKind::Workflow => workflows.push(self.parse_workflow()?),
+                TokenKind::Type => types.push(self.parse_type_def()?),
                 other => {
                     return Err(ParseError::new(
                         format!(
-                            "expected 'defaults', 'provider', 'tool', 'agent', or 'workflow', got {other}"
+                            "expected top-level declaration (defaults, provider, tool, agent, workflow, type), got {other}"
                         ),
                         self.current_span(),
                     ));
@@ -228,6 +231,7 @@ impl Parser {
             tools,
             agents,
             workflows,
+            types,
         })
     }
 
@@ -845,6 +849,83 @@ impl Parser {
                     ));
                 }
             }
+        }
+    }
+
+    /// Parse a `type Name { field: type_expr, ... }` definition.
+    fn parse_type_def(&mut self) -> Result<TypeDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Type)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut fields = Vec::new();
+        loop {
+            self.skip_comments();
+            if *self.peek() == TokenKind::RBrace {
+                break;
+            }
+            let field_start = self.current_span().start;
+            let (field_name, _) = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let type_expr = self.parse_type_expr()?;
+            let field_end = self.current_span().start;
+            fields.push(TypeField {
+                name: field_name,
+                type_expr,
+                span: Span::new(field_start, field_end),
+            });
+        }
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(TypeDef {
+            name,
+            fields,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse a type expression: named type, array, one of, or range.
+    fn parse_type_expr(&mut self) -> Result<TypeExpr, ParseError> {
+        self.skip_comments();
+        match self.peek().clone() {
+            TokenKind::One => self.parse_one_of(),
+            TokenKind::Number(n) => {
+                let min = n.clone();
+                self.advance();
+                self.expect(&TokenKind::DotDot)?;
+                match self.peek().clone() {
+                    TokenKind::Number(max) => {
+                        let max = max.clone();
+                        self.advance();
+                        Ok(TypeExpr::Range { min, max })
+                    }
+                    other => Err(ParseError::new(
+                        format!("expected number after '..', got {other}"),
+                        self.current_span(),
+                    )),
+                }
+            }
+            TokenKind::Ident(name) => {
+                let name = name.clone();
+                self.advance();
+                // Check for array syntax: Type[]
+                let array = if *self.peek() == TokenKind::LBracket
+                    && self.peek_at(1).is_some_and(|t| *t == TokenKind::RBracket)
+                {
+                    self.advance(); // [
+                    self.advance(); // ]
+                    true
+                } else {
+                    false
+                };
+                Ok(TypeExpr::Named { name, array })
+            }
+            other => Err(ParseError::new(
+                format!("expected type expression, got {other}"),
+                self.current_span(),
+            )),
         }
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ast::Constraint;
+use crate::ast::{Constraint, TypeExpr};
 
 fn parse_ok(src: &str) -> ReinFile {
     parse(src).expect("expected parse to succeed")
@@ -1059,6 +1059,7 @@ fn parse_step_with_one_of_constraint() {
         crate::ast::TypeExpr::OneOf { variants, .. } => {
             assert_eq!(variants, &["billing", "technical", "general"]);
         }
+        other => panic!("expected OneOf, got {other:?}"),
     }
 }
 
@@ -1124,5 +1125,105 @@ fn parse_one_of_trailing_comma() {
         crate::ast::TypeExpr::OneOf { variants, .. } => {
             assert_eq!(variants, &["open", "closed"]);
         }
+        other => panic!("expected OneOf, got {other:?}"),
     }
+}
+
+// ── type system tests ───────────────────────────────────────────────────
+
+#[test]
+fn parse_type_def_basic() {
+    let f = parse_ok(
+        r#"
+        type TicketClassification {
+            category: one of [billing, technical, general]
+            confidence: percent
+            tags: string[]
+        }
+    "#,
+    );
+    assert_eq!(f.types.len(), 1);
+    let td = &f.types[0];
+    assert_eq!(td.name, "TicketClassification");
+    assert_eq!(td.fields.len(), 3);
+
+    assert_eq!(td.fields[0].name, "category");
+    assert!(matches!(&td.fields[0].type_expr, TypeExpr::OneOf { variants, .. } if variants.len() == 3));
+
+    assert_eq!(td.fields[1].name, "confidence");
+    assert!(matches!(&td.fields[1].type_expr, TypeExpr::Named { name, array: false } if name == "percent"));
+
+    assert_eq!(td.fields[2].name, "tags");
+    assert!(matches!(&td.fields[2].type_expr, TypeExpr::Named { name, array: true } if name == "string"));
+}
+
+#[test]
+fn parse_type_def_builtins() {
+    let f = parse_ok(
+        r#"
+        type Record {
+            name: string
+            age: int
+            score: float
+            active: bool
+            price: currency
+            elapsed: duration
+        }
+    "#,
+    );
+    let td = &f.types[0];
+    assert_eq!(td.fields.len(), 6);
+    let names: Vec<&str> = td.fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, &["name", "age", "score", "active", "price", "elapsed"]);
+}
+
+#[test]
+fn parse_type_def_with_range() {
+    let f = parse_ok(
+        r#"
+        type Config {
+            temperature: 0..100
+        }
+    "#,
+    );
+    let td = &f.types[0];
+    assert!(matches!(&td.fields[0].type_expr, TypeExpr::Range { min, max } if min == "0" && max == "100"));
+}
+
+#[test]
+fn parse_type_def_float_range() {
+    let f = parse_ok(
+        r#"
+        type Config {
+            temperature: 0.0..1.0
+        }
+    "#,
+    );
+    let td = &f.types[0];
+    assert!(matches!(&td.fields[0].type_expr, TypeExpr::Range { min, max } if min == "0.0" && max == "1.0"));
+}
+
+#[test]
+fn parse_multiple_type_defs() {
+    let f = parse_ok(
+        r#"
+        type A { x: int }
+        type B { y: string }
+    "#,
+    );
+    assert_eq!(f.types.len(), 2);
+    assert_eq!(f.types[0].name, "A");
+    assert_eq!(f.types[1].name, "B");
+}
+
+#[test]
+fn parse_type_with_agents() {
+    let f = parse_ok(
+        r#"
+        type Output { status: one of [ok, error] }
+        agent bot { model: openai }
+    "#,
+    );
+    assert_eq!(f.types.len(), 1);
+    assert_eq!(f.agents.len(), 1);
 }

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -97,6 +97,7 @@ fn zero_budget_detected() {
             span: Span::new(0, 1),
         }],
         workflows: vec![],
+        types: vec![],
     };
     let diags = validate(&file);
     let errs = errors(&diags);


### PR DESCRIPTION
Closes #118

Adds `type Name { field: type_expr }` definitions to the Rein language.

**Type expressions supported:**
- Named types (built-ins: string, float, int, bool, currency, duration, percent, or user-defined)
- Array types: `Type[]`
- Union types: `one of [a, b, c]` (from #144)
- Ranges: `0..100`, `0.0..1.0`

**New tokens:** `type`, `Number`, `DotDot` (`..`)
**AST:** `TypeDef`, `TypeField`, expanded `TypeExpr`
**Parser:** `parse_type_def`, `parse_type_expr` methods