### PR TITLE
feat(parser): import system

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -228,6 +228,29 @@ pub struct TypeDef {
     pub span: Span,
 }
 
+/// An import declaration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDef {
+    /// Named imports: `import { name1, name2 } from "./path.rein"`.
+    Named {
+        names: Vec<String>,
+        source: String,
+        span: Span,
+    },
+    /// Glob import: `import all from "./dir/"`.
+    Glob {
+        source: String,
+        span: Span,
+    },
+    /// Registry import: `import from @scope/name`.
+    Registry {
+        scope: String,
+        name: String,
+        span: Span,
+    },
+}
+
 /// How a condition is evaluated against agent output.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "mode", content = "value", rename_all = "snake_case")]
@@ -322,6 +345,7 @@ impl WorkflowDef {
 /// Top-level parsed file — provider, agent, and workflow definitions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReinFile {
+    pub imports: Vec<ImportDef>,
     pub defaults: Option<DefaultsDef>,
     pub providers: Vec<ProviderDef>,
     pub tools: Vec<ToolDef>,
@@ -437,6 +461,7 @@ mod tests {
     #[test]
     fn rein_file_roundtrips_via_json() {
         let file = ReinFile {
+            imports: vec![],
             defaults: None,
             providers: vec![],
             tools: vec![],
@@ -551,6 +576,7 @@ mod tests {
     #[test]
     fn rein_file_with_workflows_roundtrips() {
         let file = ReinFile {
+            imports: vec![],
             defaults: None,
             providers: vec![],
             tools: vec![],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -26,6 +26,11 @@ pub enum TokenKind {
     One,
     Of,
     Type,
+    Import,
+    From,
+    All,
+    At,
+    Slash,
     // Symbols
     LBrace,
     RBrace,
@@ -86,6 +91,11 @@ impl std::fmt::Display for TokenKind {
             TokenKind::One => write!(f, "one"),
             TokenKind::Of => write!(f, "of"),
             TokenKind::Type => write!(f, "type"),
+            TokenKind::Import => write!(f, "import"),
+            TokenKind::From => write!(f, "from"),
+            TokenKind::All => write!(f, "all"),
+            TokenKind::At => write!(f, "@"),
+            TokenKind::Slash => write!(f, "/"),
             TokenKind::DotDot => write!(f, ".."),
             TokenKind::Number(n) => write!(f, "{n}"),
             TokenKind::Ident(s) => write!(f, "{s}"),
@@ -215,6 +225,9 @@ impl<'a> Lexer<'a> {
             "one" => TokenKind::One,
             "of" => TokenKind::Of,
             "type" => TokenKind::Type,
+            "import" => TokenKind::Import,
+            "from" => TokenKind::From,
+            "all" => TokenKind::All,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)
@@ -402,6 +415,8 @@ impl<'a> Lexer<'a> {
                     self.advance(); // '*'
                     tokens.push(self.skip_block_comment(start)?);
                 }
+                Some(b'/') => tokens.push(Token::new(TokenKind::Slash, start, self.pos)),
+                Some(b'@') => tokens.push(Token::new(TokenKind::At, start, self.pos)),
                 Some(ch) if ch.is_ascii_digit() => {
                     tokens.push(self.read_number(start));
                 }

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -245,10 +245,10 @@ fn error_unterminated_string_literal() {
 
 #[test]
 fn error_on_invalid_char() {
-    let result = tokenize("agent @ foo");
+    let result = tokenize("agent ~ foo");
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(err.message.contains('@'));
+    assert!(err.message.contains('~'));
 }
 
 #[test]
@@ -261,10 +261,10 @@ fn error_on_unterminated_block_comment() {
 
 #[test]
 fn error_span_points_to_bad_char() {
-    let src = "foo @";
+    let src = "foo ~";
     let result = tokenize(src);
     let err = result.unwrap_err();
-    // '@' is at byte offset 4
+    // '~' is at byte offset 4
     assert_eq!(err.span.start, 4);
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     AgentDef, Budget, Capability, Constraint, DefaultsDef, ExecutionMode, GuardrailRule,
     GuardrailSection, GuardrailsDef, ProviderDef, ReinFile, RouteRule, Span, Stage, ToolDef,
-    TypeDef, TypeExpr, TypeField, ValueExpr, WorkflowDef,
+    ImportDef, TypeDef, TypeExpr, TypeField, ValueExpr, WorkflowDef,
 
 };
 use crate::lexer::{Token, TokenKind, tokenize};
@@ -192,6 +192,7 @@ impl Parser {
 
     pub fn parse_file(&mut self) -> Result<ReinFile, ParseError> {
         self.skip_comments();
+        let mut imports = Vec::new();
         let mut defaults: Option<DefaultsDef> = None;
         let mut providers = Vec::new();
         let mut tools = Vec::new();
@@ -200,6 +201,7 @@ impl Parser {
         let mut types = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
+                TokenKind::Import => imports.push(self.parse_import()?),
                 TokenKind::Defaults => {
                     if defaults.is_some() {
                         return Err(ParseError::new(
@@ -226,6 +228,7 @@ impl Parser {
             self.skip_comments();
         }
         Ok(ReinFile {
+            imports,
             defaults,
             providers,
             tools,
@@ -849,6 +852,95 @@ impl Parser {
                     ));
                 }
             }
+        }
+    }
+
+    /// Parse an import declaration.
+    ///
+    /// Supports:
+    /// - `import { name1, name2 } from "./path.rein"`
+    /// - `import all from "./dir/"`
+    /// - `import from @scope/name`
+    fn parse_import(&mut self) -> Result<ImportDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Import)?;
+
+        match self.peek().clone() {
+            // import { name, ... } from "path"
+            TokenKind::LBrace => {
+                self.advance(); // {
+                let mut names = Vec::new();
+                loop {
+                    self.skip_comments();
+                    if *self.peek() == TokenKind::RBrace {
+                        break;
+                    }
+                    let (name, _) = self.expect_ident()?;
+                    names.push(name);
+                    self.skip_comments();
+                    if *self.peek() == TokenKind::Comma {
+                        self.advance();
+                    }
+                }
+                self.expect(&TokenKind::RBrace)?;
+                self.expect(&TokenKind::From)?;
+                let source = self.expect_string()?;
+                let end = self.current_span().start;
+                Ok(ImportDef::Named {
+                    names,
+                    source,
+                    span: Span::new(start, end),
+                })
+            }
+            // import all from "path"
+            TokenKind::All => {
+                self.advance(); // all
+                self.expect(&TokenKind::From)?;
+                let source = self.expect_string()?;
+                let end = self.current_span().start;
+                Ok(ImportDef::Glob {
+                    source,
+                    span: Span::new(start, end),
+                })
+            }
+            // import from @scope/name
+            TokenKind::From => {
+                self.advance(); // from
+                self.expect(&TokenKind::At)?;
+                let (scope, _) = self.expect_ident()?;
+                // Expect '/' separator — we'll use Ident since / isn't a token
+                // Actually, we need a slash. Let me handle this differently.
+                // For @scope/name, we'll read the rest as ident after consuming
+                // what we can. Since '/' isn't a token, we'll expect the name
+                // to be separated by checking for Dot or another convention.
+                self.expect(&TokenKind::Slash)?;
+                let (name, _) = self.expect_ident()?;
+                let end = self.current_span().start;
+                Ok(ImportDef::Registry {
+                    scope,
+                    name,
+                    span: Span::new(start, end),
+                })
+            }
+            other => Err(ParseError::new(
+                format!("expected '{{', 'all', or 'from' after 'import', got {other}"),
+                self.current_span(),
+            )),
+        }
+    }
+
+    /// Expect a string literal and return its value.
+    fn expect_string(&mut self) -> Result<String, ParseError> {
+        match self.peek().clone() {
+            TokenKind::StringLiteral(s) => {
+                let s = s.clone();
+                self.advance();
+                Ok(s)
+            }
+            other => Err(ParseError::new(
+                format!("expected string literal, got {other}"),
+                self.current_span(),
+            )),
         }
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1227,3 +1227,86 @@ fn parse_type_with_agents() {
     assert_eq!(f.types.len(), 1);
     assert_eq!(f.agents.len(), 1);
 }
+
+// ── import system tests ─────────────────────────────────────────────────
+
+#[test]
+fn parse_named_import() {
+    let f = parse_ok(
+        r#"
+        import { classifier, responder } from "./agents/support.rein"
+        agent classifier { model: openai }
+        agent responder { model: openai }
+    "#,
+    );
+    assert_eq!(f.imports.len(), 1);
+    match &f.imports[0] {
+        crate::ast::ImportDef::Named { names, source, .. } => {
+            assert_eq!(names, &["classifier", "responder"]);
+            assert_eq!(source, "./agents/support.rein");
+        }
+        other => panic!("expected Named import, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_glob_import() {
+    let f = parse_ok(
+        r#"
+        import all from "./agents/"
+    "#,
+    );
+    assert_eq!(f.imports.len(), 1);
+    match &f.imports[0] {
+        crate::ast::ImportDef::Glob { source, .. } => {
+            assert_eq!(source, "./agents/");
+        }
+        other => panic!("expected Glob import, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_registry_import() {
+    let f = parse_ok(
+        r#"
+        import from @rein/support
+    "#,
+    );
+    assert_eq!(f.imports.len(), 1);
+    match &f.imports[0] {
+        crate::ast::ImportDef::Registry { scope, name, .. } => {
+            assert_eq!(scope, "rein");
+            assert_eq!(name, "support");
+        }
+        other => panic!("expected Registry import, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_multiple_imports() {
+    let f = parse_ok(
+        r#"
+        import { bot } from "./bot.rein"
+        import all from "./shared/"
+        import from @rein/stdlib
+        agent bot { model: openai }
+    "#,
+    );
+    assert_eq!(f.imports.len(), 3);
+    assert_eq!(f.agents.len(), 1);
+}
+
+#[test]
+fn parse_import_single_name() {
+    let f = parse_ok(
+        r#"
+        import { classifier } from "./classifier.rein"
+    "#,
+    );
+    match &f.imports[0] {
+        crate::ast::ImportDef::Named { names, .. } => {
+            assert_eq!(names, &["classifier"]);
+        }
+        other => panic!("expected Named import, got {other:?}"),
+    }
+}

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -79,6 +79,7 @@ fn zero_budget_detected() {
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile {
+            imports: vec![],
         defaults: None,
         providers: vec![],
         tools: vec![],


### PR DESCRIPTION
Closes #119

Three import forms:
- `import { name1, name2 } from "./path.rein"` — named imports
- `import all from "./dir/"` — glob imports  
- `import from @scope/name` — registry imports

New tokens: `import`, `from`, `all`, `@`, `/`
New AST: `ImportDef` enum with Named, Glob, Registry variants