### PR TITLE
feat(parser): route on block syntax

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -228,6 +228,36 @@ pub struct TypeDef {
     pub span: Span,
 }
 
+/// A single arm in a `route on` block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouteArm {
+    /// The match pattern: a literal value or `_` for wildcard/default.
+    pub pattern: RoutePattern,
+    /// The step to execute if this arm matches.
+    pub step: StepDef,
+    pub span: Span,
+}
+
+/// A match pattern in a route arm.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoutePattern {
+    /// Match a specific value.
+    Value(String),
+    /// Wildcard: match anything not matched above.
+    Wildcard,
+}
+
+/// A `route on <expr> { ... }` block for pattern-matched routing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouteBlock {
+    /// Dot-separated field path to match on (e.g. `classify.category`).
+    pub field_path: String,
+    /// Match arms in order.
+    pub arms: Vec<RouteArm>,
+    pub span: Span,
+}
+
 /// An import declaration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -326,6 +356,8 @@ pub struct WorkflowDef {
     pub stages: Vec<Stage>,
     /// Named step blocks (`step <name> { ... }`).
     pub steps: Vec<StepDef>,
+    /// Route-on blocks for pattern-matched routing.
+    pub route_blocks: Vec<RouteBlock>,
     /// Default execution mode.
     pub mode: ExecutionMode,
     pub span: Span,
@@ -548,6 +580,7 @@ mod tests {
                 },
             ],
             steps: vec![],
+            route_blocks: vec![],
             mode: ExecutionMode::Sequential,
             span: dummy_span(),
         };
@@ -565,6 +598,7 @@ mod tests {
             trigger: "event".to_string(),
             stages: vec![],
             steps: vec![],
+            route_blocks: vec![],
             mode: ExecutionMode::Parallel,
             span: dummy_span(),
         };
@@ -586,6 +620,7 @@ mod tests {
                 trigger: "event".to_string(),
                 stages: vec![],
                 steps: vec![],
+            route_blocks: vec![],
                 mode: ExecutionMode::Sequential,
                 span: dummy_span(),
             }],
@@ -616,6 +651,7 @@ mod tests {
                 },
             ],
             steps: vec![],
+            route_blocks: vec![],
             mode: ExecutionMode::Sequential,
             span: dummy_span(),
         };

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -31,6 +31,10 @@ pub enum TokenKind {
     All,
     At,
     Slash,
+    Arrow,
+    Route,
+    On,
+    Underscore,
     // Symbols
     LBrace,
     RBrace,
@@ -96,6 +100,10 @@ impl std::fmt::Display for TokenKind {
             TokenKind::All => write!(f, "all"),
             TokenKind::At => write!(f, "@"),
             TokenKind::Slash => write!(f, "/"),
+            TokenKind::Arrow => write!(f, "->"),
+            TokenKind::Route => write!(f, "route"),
+            TokenKind::On => write!(f, "on"),
+            TokenKind::Underscore => write!(f, "_"),
             TokenKind::DotDot => write!(f, ".."),
             TokenKind::Number(n) => write!(f, "{n}"),
             TokenKind::Ident(s) => write!(f, "{s}"),
@@ -228,6 +236,9 @@ impl<'a> Lexer<'a> {
             "import" => TokenKind::Import,
             "from" => TokenKind::From,
             "all" => TokenKind::All,
+            "route" => TokenKind::Route,
+            "on" => TokenKind::On,
+            "_" => TokenKind::Underscore,
             _ => TokenKind::Ident(word.to_string()),
         };
         Token::new(kind, start, end)
@@ -417,6 +428,10 @@ impl<'a> Lexer<'a> {
                 }
                 Some(b'/') => tokens.push(Token::new(TokenKind::Slash, start, self.pos)),
                 Some(b'@') => tokens.push(Token::new(TokenKind::At, start, self.pos)),
+                Some(b'-') if self.peek() == Some(b'>') => {
+                    self.advance(); // consume '>'
+                    tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
+                }
                 Some(ch) if ch.is_ascii_digit() => {
                     tokens.push(self.read_number(start));
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -637,6 +637,7 @@ impl Parser {
         let mut trigger: Option<String> = None;
         let mut stages: Vec<Stage> = Vec::new();
         let mut steps: Vec<crate::ast::StepDef> = Vec::new();
+        let mut route_blocks: Vec<crate::ast::RouteBlock> = Vec::new();
         let mut seen_trigger = false;
         let mut seen_stages = false;
 
@@ -654,9 +655,9 @@ impl Parser {
                         )
                     })?;
 
-                    if stages.is_empty() && steps.is_empty() {
+                    if stages.is_empty() && steps.is_empty() && route_blocks.is_empty() {
                         return Err(ParseError::new(
-                            format!("workflow '{name}' must have at least one stage or step"),
+                            format!("workflow '{name}' must have at least one stage, step, or route block"),
                             Span::new(start, end),
                         ));
                     }
@@ -666,6 +667,7 @@ impl Parser {
                         trigger,
                         stages,
                         steps,
+                        route_blocks,
                         mode: ExecutionMode::Sequential,
                         span: Span::new(start, end),
                     });
@@ -696,6 +698,9 @@ impl Parser {
                 }
                 TokenKind::Step => {
                     steps.push(self.parse_step()?);
+                }
+                TokenKind::Route => {
+                    route_blocks.push(self.parse_route_block()?);
                 }
                 TokenKind::Eof => {
                     return Err(ParseError::new(
@@ -855,6 +860,68 @@ impl Parser {
         }
     }
 
+    /// Parse a `route on <field_path> { pattern -> step name { ... }, ... }` block.
+    fn parse_route_block(&mut self) -> Result<crate::ast::RouteBlock, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Route)?;
+        self.expect(&TokenKind::On)?;
+
+        // Parse dot-separated field path (keywords allowed as segments)
+        let (first, _) = self.expect_ident()?;
+        let mut path = first;
+        while *self.peek() == TokenKind::Dot {
+            self.advance(); // .
+            // Allow keywords as path segments
+            let segment = self.expect_ident_or_keyword()?;
+            path.push('.');
+            path.push_str(&segment);
+        }
+
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut arms = Vec::new();
+        loop {
+            self.skip_comments();
+            if *self.peek() == TokenKind::RBrace {
+                break;
+            }
+            let arm_start = self.current_span().start;
+            let pattern = match self.peek().clone() {
+                TokenKind::Underscore => {
+                    self.advance();
+                    crate::ast::RoutePattern::Wildcard
+                }
+                TokenKind::Ident(val) => {
+                    let val = val.clone();
+                    self.advance();
+                    crate::ast::RoutePattern::Value(val)
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("expected pattern value or '_', got {other}"),
+                        self.current_span(),
+                    ));
+                }
+            };
+            self.expect(&TokenKind::Arrow)?;
+            let step = self.parse_step()?;
+            let arm_end = self.current_span().start;
+            arms.push(crate::ast::RouteArm {
+                pattern,
+                step,
+                span: Span::new(arm_start, arm_end),
+            });
+        }
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(crate::ast::RouteBlock {
+            field_path: path,
+            arms,
+            span: Span::new(start, end),
+        })
+    }
+
     /// Parse an import declaration.
     ///
     /// Supports:
@@ -924,6 +991,35 @@ impl Parser {
             }
             other => Err(ParseError::new(
                 format!("expected '{{', 'all', or 'from' after 'import', got {other}"),
+                self.current_span(),
+            )),
+        }
+    }
+
+    /// Expect an identifier or keyword token, returning the text.
+    /// Useful in contexts where keywords are valid (e.g. field paths).
+    fn expect_ident_or_keyword(&mut self) -> Result<String, ParseError> {
+        let text = self.peek().to_string();
+        match self.peek() {
+            TokenKind::Ident(_)
+            | TokenKind::Agent
+            | TokenKind::Model
+            | TokenKind::Type
+            | TokenKind::Step
+            | TokenKind::Goal
+            | TokenKind::Tool
+            | TokenKind::Route
+            | TokenKind::On
+            | TokenKind::One
+            | TokenKind::Of
+            | TokenKind::All
+            | TokenKind::From
+            | TokenKind::Import => {
+                self.advance();
+                Ok(text)
+            }
+            other => Err(ParseError::new(
+                format!("expected identifier, got {other}"),
                 self.current_span(),
             )),
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1310,3 +1310,81 @@ fn parse_import_single_name() {
         other => panic!("expected Named import, got {other:?}"),
     }
 }
+
+// ── route on block tests ────────────────────────────────────────────────
+
+#[test]
+fn parse_route_on_basic() {
+    let f = parse_ok(
+        r#"
+        agent classifier { model: openai }
+        agent billing_handler { model: openai }
+        agent default_handler { model: openai }
+        workflow support {
+            trigger: ticket
+            route on classify.category {
+                billing -> step handle_billing {
+                    agent: billing_handler
+                    goal: "Handle billing"
+                }
+                _ -> step escalate {
+                    agent: default_handler
+                    goal: "Escalate"
+                }
+            }
+        }
+    "#,
+    );
+    let wf = &f.workflows[0];
+    assert_eq!(wf.route_blocks.len(), 1);
+    let rb = &wf.route_blocks[0];
+    assert_eq!(rb.field_path, "classify.category");
+    assert_eq!(rb.arms.len(), 2);
+    assert!(matches!(&rb.arms[0].pattern, crate::ast::RoutePattern::Value(v) if v == "billing"));
+    assert_eq!(rb.arms[0].step.name, "handle_billing");
+    assert!(matches!(&rb.arms[1].pattern, crate::ast::RoutePattern::Wildcard));
+    assert_eq!(rb.arms[1].step.name, "escalate");
+}
+
+#[test]
+fn parse_route_on_multiple_arms() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        agent b { model: openai }
+        agent c { model: openai }
+        workflow w {
+            trigger: event
+            route on result.status {
+                success -> step ok { agent: a }
+                failure -> step fail { agent: b }
+                _ -> step unknown { agent: c }
+            }
+        }
+    "#,
+    );
+    let rb = &f.workflows[0].route_blocks[0];
+    assert_eq!(rb.arms.len(), 3);
+    assert!(matches!(&rb.arms[0].pattern, crate::ast::RoutePattern::Value(v) if v == "success"));
+    assert!(matches!(&rb.arms[1].pattern, crate::ast::RoutePattern::Value(v) if v == "failure"));
+    assert!(matches!(&rb.arms[2].pattern, crate::ast::RoutePattern::Wildcard));
+}
+
+#[test]
+fn parse_route_on_with_steps() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        agent b { model: openai }
+        workflow w {
+            trigger: event
+            step classify { agent: a goal: "Classify" }
+            route on classify.type {
+                billing -> step handle { agent: b }
+            }
+        }
+    "#,
+    );
+    assert_eq!(f.workflows[0].steps.len(), 1);
+    assert_eq!(f.workflows[0].route_blocks.len(), 1);
+}

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -34,6 +34,7 @@ fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDe
             })
             .collect(),
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }
@@ -353,6 +354,7 @@ fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
             },
         ],
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -453,6 +455,7 @@ async fn conditional_no_else_ends_workflow() {
             },
         ],
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -881,6 +884,7 @@ async fn conditional_route_to_nonexistent_stage_errors() {
             span: Span::new(0, 1),
         }],
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };
@@ -947,6 +951,7 @@ async fn circular_route_returns_error() {
             },
         ],
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     };

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -270,6 +270,7 @@ fn make_workflow(name: &str, trigger: &str, agents: &[&str]) -> WorkflowDef {
             })
             .collect(),
         steps: vec![],
+            route_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }


### PR DESCRIPTION
Closes #125

Adds `route on <field.path> { value -> step name { ... }, _ -> step default { ... } }` syntax for pattern-matched routing in workflows.

- New tokens: `route`, `on`, `_` (wildcard), `->` (arrow)
- AST: `RouteBlock`, `RouteArm`, `RoutePattern`
- Parser handles dot-separated field paths (keywords allowed as segments)
- Supports value patterns and wildcard default