### PR TITLE
feat(parser): when expressions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -228,6 +228,46 @@ pub struct TypeDef {
     pub span: Span,
 }
 
+/// A comparison operator in a `when` expression.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CompareOp {
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+}
+
+/// A value in a `when` comparison (right-hand side).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WhenValue {
+    /// A percentage like `70%`.
+    Percent(String),
+    /// A currency amount like `$50`.
+    Currency { symbol: char, amount: u64 },
+    /// A plain number.
+    Number(String),
+    /// An identifier reference.
+    Ident(String),
+}
+
+/// A single comparison in a `when` expression: `field op value`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WhenComparison {
+    pub field: String,
+    pub op: CompareOp,
+    pub value: WhenValue,
+}
+
+/// A `when` expression combining comparisons with boolean logic.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WhenExpr {
+    Comparison(WhenComparison),
+    And(Vec<WhenExpr>),
+    Or(Vec<WhenExpr>),
+}
+
 /// A `parallel { step a {...} step b {...} }` block for concurrent execution.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParallelBlock {
@@ -350,6 +390,8 @@ pub struct StepDef {
     pub goal: Option<String>,
     /// Output type constraints (e.g. `category: one of [billing, technical]`).
     pub output_constraints: Vec<(String, TypeExpr)>,
+    /// Optional guard condition: `when: confidence < 70%`.
+    pub when: Option<WhenExpr>,
     pub span: Span,
 }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -35,7 +35,15 @@ pub enum TokenKind {
     Parallel,
     Route,
     On,
+    When,
+    Or,
+    And,
     Underscore,
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+    Percent,
     // Symbols
     LBrace,
     RBrace,
@@ -102,6 +110,14 @@ impl std::fmt::Display for TokenKind {
             TokenKind::At => write!(f, "@"),
             TokenKind::Slash => write!(f, "/"),
             TokenKind::Parallel => write!(f, "parallel"),
+            TokenKind::When => write!(f, "when"),
+            TokenKind::Or => write!(f, "or"),
+            TokenKind::And => write!(f, "and"),
+            TokenKind::Lt => write!(f, "<"),
+            TokenKind::Gt => write!(f, ">"),
+            TokenKind::LtEq => write!(f, "<="),
+            TokenKind::GtEq => write!(f, ">="),
+            TokenKind::Percent => write!(f, "%"),
             TokenKind::Arrow => write!(f, "->"),
             TokenKind::Route => write!(f, "route"),
             TokenKind::On => write!(f, "on"),
@@ -239,6 +255,9 @@ impl<'a> Lexer<'a> {
             "from" => TokenKind::From,
             "all" => TokenKind::All,
             "parallel" => TokenKind::Parallel,
+            "when" => TokenKind::When,
+            "or" => TokenKind::Or,
+            "and" => TokenKind::And,
             "route" => TokenKind::Route,
             "on" => TokenKind::On,
             "_" => TokenKind::Underscore,
@@ -435,6 +454,23 @@ impl<'a> Lexer<'a> {
                     self.advance(); // consume '>'
                     tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
                 }
+                Some(b'<') => {
+                    if self.peek() == Some(b'=') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::LtEq, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Lt, start, self.pos));
+                    }
+                }
+                Some(b'>') => {
+                    if self.peek() == Some(b'=') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::GtEq, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Gt, start, self.pos));
+                    }
+                }
+                Some(b'%') => tokens.push(Token::new(TokenKind::Percent, start, self.pos)),
                 Some(ch) if ch.is_ascii_digit() => {
                     tokens.push(self.read_number(start));
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -762,6 +762,7 @@ impl Parser {
     }
 
     /// Parse a `step <name> { agent: <ident> goal: <text> }` block.
+    #[allow(clippy::too_many_lines)]
     fn parse_step(&mut self) -> Result<crate::ast::StepDef, ParseError> {
         self.skip_comments();
         let start = self.current_span().start;
@@ -773,6 +774,7 @@ impl Parser {
         let mut agent: Option<String> = None;
         let mut goal: Option<String> = None;
         let mut output_constraints: Vec<(String, TypeExpr)> = Vec::new();
+        let mut when: Option<crate::ast::WhenExpr> = None;
         let mut seen_agent = false;
         let mut seen_goal = false;
 
@@ -795,6 +797,7 @@ impl Parser {
                         agent,
                         goal,
                         output_constraints,
+                        when,
                         span: Span::new(start, end),
                     });
                 }
@@ -833,6 +836,17 @@ impl Parser {
                         }
                     });
                 }
+                TokenKind::When => {
+                    if when.is_some() {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'when' in step '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    when = Some(self.parse_when_expr()?);
+                }
                 TokenKind::Ident(ref field_name)
                     if self.peek_at(1).is_some_and(|t| *t == TokenKind::Colon) =>
                 {
@@ -862,6 +876,101 @@ impl Parser {
                     ));
                 }
             }
+        }
+    }
+
+    /// Parse a `when` expression: `field op value [or|and field op value ...]`.
+    fn parse_when_expr(&mut self) -> Result<crate::ast::WhenExpr, ParseError> {
+        let first = self.parse_when_comparison()?;
+        let mut expr = crate::ast::WhenExpr::Comparison(first);
+
+        loop {
+            self.skip_comments();
+            match self.peek() {
+                TokenKind::Or => {
+                    self.advance();
+                    let next = self.parse_when_comparison()?;
+                    expr = match expr {
+                        crate::ast::WhenExpr::Or(mut parts) => {
+                            parts.push(crate::ast::WhenExpr::Comparison(next));
+                            crate::ast::WhenExpr::Or(parts)
+                        }
+                        other => crate::ast::WhenExpr::Or(vec![
+                            other,
+                            crate::ast::WhenExpr::Comparison(next),
+                        ]),
+                    };
+                }
+                TokenKind::And => {
+                    self.advance();
+                    let next = self.parse_when_comparison()?;
+                    expr = match expr {
+                        crate::ast::WhenExpr::And(mut parts) => {
+                            parts.push(crate::ast::WhenExpr::Comparison(next));
+                            crate::ast::WhenExpr::And(parts)
+                        }
+                        other => crate::ast::WhenExpr::And(vec![
+                            other,
+                            crate::ast::WhenExpr::Comparison(next),
+                        ]),
+                    };
+                }
+                _ => break,
+            }
+        }
+        Ok(expr)
+    }
+
+    /// Parse a single comparison: `field op value`.
+    fn parse_when_comparison(&mut self) -> Result<crate::ast::WhenComparison, ParseError> {
+        let (field, _) = self.expect_ident()?;
+
+        let op = match self.peek() {
+            TokenKind::Lt => crate::ast::CompareOp::Lt,
+            TokenKind::Gt => crate::ast::CompareOp::Gt,
+            TokenKind::LtEq => crate::ast::CompareOp::LtEq,
+            TokenKind::GtEq => crate::ast::CompareOp::GtEq,
+            other => {
+                return Err(ParseError::new(
+                    format!("expected comparison operator (<, >, <=, >=), got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+        self.advance();
+
+        let value = self.parse_when_value()?;
+
+        Ok(crate::ast::WhenComparison { field, op, value })
+    }
+
+    /// Parse a when value: number, percent, currency, or ident.
+    fn parse_when_value(&mut self) -> Result<crate::ast::WhenValue, ParseError> {
+        match self.peek().clone() {
+            TokenKind::Number(n) => {
+                let n = n.clone();
+                self.advance();
+                // Check for trailing %
+                if *self.peek() == TokenKind::Percent {
+                    self.advance();
+                    Ok(crate::ast::WhenValue::Percent(n))
+                } else {
+                    Ok(crate::ast::WhenValue::Number(n))
+                }
+            }
+            TokenKind::Currency { symbol, amount } => {
+                self.advance();
+                Ok(crate::ast::WhenValue::Currency { symbol, amount })
+            }
+            TokenKind::Ident(name) => {
+                let name = name.clone();
+                self.advance();
+                Ok(crate::ast::WhenValue::Ident(name))
+            }
+            other => Err(ParseError::new(
+                format!("expected value (number, percentage, currency, or identifier), got {other}"),
+                self.current_span(),
+            )),
         }
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1446,3 +1446,114 @@ fn parse_parallel_empty_errors() {
     );
     assert!(err.message.contains("at least one"), "got: {}", err.message);
 }
+
+// ── when expression tests ───────────────────────────────────────────────
+
+#[test]
+fn parse_step_with_when_percent() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: confidence < 70%
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Comparison(c) => {
+            assert_eq!(c.field, "confidence");
+            assert_eq!(c.op, crate::ast::CompareOp::Lt);
+            assert!(matches!(&c.value, crate::ast::WhenValue::Percent(p) if p == "70"));
+        }
+        other => panic!("expected Comparison, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_step_with_when_currency() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: refund > $50.00
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Comparison(c) => {
+            assert_eq!(c.field, "refund");
+            assert_eq!(c.op, crate::ast::CompareOp::Gt);
+            assert!(matches!(&c.value, crate::ast::WhenValue::Currency { symbol: '$', amount: 5000 }));
+        }
+        other => panic!("expected Comparison, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_step_with_when_or() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: confidence < 70% or refund > $50.00
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Or(parts) => {
+            assert_eq!(parts.len(), 2);
+        }
+        other => panic!("expected Or, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_step_with_when_and() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: score >= 80 and priority < 3
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    assert!(matches!(when, crate::ast::WhenExpr::And(parts) if parts.len() == 2));
+}
+
+#[test]
+fn parse_step_without_when() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x { agent: a }
+        }
+    "#,
+    );
+    assert!(f.workflows[0].steps[0].when.is_none());
+}


### PR DESCRIPTION
Closes #128

Adds `when: confidence < 70% or refund > $50` guard conditions to step definitions.

- Comparison operators: `<`, `>`, `<=`, `>=`
- Boolean combinators: `or`, `and`
- Value types: numbers, percentages (`70%`), currency (`$50`), identifiers
- AST: `WhenExpr`, `WhenComparison`, `CompareOp`, `WhenValue`