### PR TITLE
fix(parser): and/or operator precedence in when expressions

### DIFF
--- a/src/parser/step_parser.rs
+++ b/src/parser/step_parser.rs
@@ -230,40 +230,56 @@ impl Parser {
         }
     }
 
-    /// Parse a `when` expression: `field op value [or|and field op value ...]`.
+    /// Parse a `when` expression with proper precedence: `and` binds tighter than `or`.
+    ///
+    /// Grammar:
+    ///   `or_expr`  = `and_expr` (`or` `and_expr`)*
+    ///   `and_expr` = comparison (`and` comparison)*
     pub(super) fn parse_when_expr(&mut self) -> Result<WhenExpr, ParseError> {
-        let first = self.parse_when_comparison()?;
-        let mut expr = WhenExpr::Comparison(first);
+        self.parse_when_or_expr()
+    }
+
+    fn parse_when_or_expr(&mut self) -> Result<WhenExpr, ParseError> {
+        let first = self.parse_when_and_expr()?;
+        let mut parts = vec![first];
 
         loop {
             self.skip_comments();
-            match self.peek() {
-                TokenKind::Or => {
-                    self.advance();
-                    let next = self.parse_when_comparison()?;
-                    expr = match expr {
-                        WhenExpr::Or(mut parts) => {
-                            parts.push(WhenExpr::Comparison(next));
-                            WhenExpr::Or(parts)
-                        }
-                        other => WhenExpr::Or(vec![other, WhenExpr::Comparison(next)]),
-                    };
-                }
-                TokenKind::And => {
-                    self.advance();
-                    let next = self.parse_when_comparison()?;
-                    expr = match expr {
-                        WhenExpr::And(mut parts) => {
-                            parts.push(WhenExpr::Comparison(next));
-                            WhenExpr::And(parts)
-                        }
-                        other => WhenExpr::And(vec![other, WhenExpr::Comparison(next)]),
-                    };
-                }
-                _ => break,
+            if *self.peek() == TokenKind::Or {
+                self.advance();
+                parts.push(self.parse_when_and_expr()?);
+            } else {
+                break;
             }
         }
-        Ok(expr)
+
+        if parts.len() == 1 {
+            Ok(parts.into_iter().next().unwrap())
+        } else {
+            Ok(WhenExpr::Or(parts))
+        }
+    }
+
+    fn parse_when_and_expr(&mut self) -> Result<WhenExpr, ParseError> {
+        let first = self.parse_when_comparison()?;
+        let mut parts = vec![WhenExpr::Comparison(first)];
+
+        loop {
+            self.skip_comments();
+            if *self.peek() == TokenKind::And {
+                self.advance();
+                let next = self.parse_when_comparison()?;
+                parts.push(WhenExpr::Comparison(next));
+            } else {
+                break;
+            }
+        }
+
+        if parts.len() == 1 {
+            Ok(parts.into_iter().next().unwrap())
+        } else {
+            Ok(WhenExpr::And(parts))
+        }
     }
 
     /// Parse a single comparison: `field op value`.

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1710,3 +1710,98 @@ fn parse_workflow_without_auto_resolve() {
     );
     assert!(f.workflows[0].auto_resolve.is_none());
 }
+
+// ── when expression precedence tests ────────────────────────────────────
+
+#[test]
+fn when_and_binds_tighter_than_or() {
+    // `a > 1 or b > 2 and c > 3` should parse as `a > 1 or (b > 2 and c > 3)`
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step s {
+                agent: a
+                when: score > 50 or confidence > 80 and priority < 3
+            }
+        }
+    "#,
+    );
+    let when = f.workflows[0].steps[0].when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Or(parts) => {
+            assert_eq!(parts.len(), 2);
+            // First part is a simple comparison
+            assert!(matches!(&parts[0], crate::ast::WhenExpr::Comparison(_)));
+            // Second part is an And group
+            match &parts[1] {
+                crate::ast::WhenExpr::And(and_parts) => assert_eq!(and_parts.len(), 2),
+                other => panic!("expected And, got {other:?}"),
+            }
+        }
+        other => panic!("expected Or, got {other:?}"),
+    }
+}
+
+#[test]
+fn when_and_chain_without_or() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step s {
+                agent: a
+                when: a > 1 and b > 2 and c > 3
+            }
+        }
+    "#,
+    );
+    let when = f.workflows[0].steps[0].when.as_ref().unwrap();
+    assert!(matches!(when, crate::ast::WhenExpr::And(parts) if parts.len() == 3));
+}
+
+#[test]
+fn when_or_chain_without_and() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step s {
+                agent: a
+                when: a > 1 or b > 2 or c > 3
+            }
+        }
+    "#,
+    );
+    let when = f.workflows[0].steps[0].when.as_ref().unwrap();
+    assert!(matches!(when, crate::ast::WhenExpr::Or(parts) if parts.len() == 3));
+}
+
+#[test]
+fn when_mixed_precedence_complex() {
+    // `a > 1 and b > 2 or c > 3 and d > 4` = `(a > 1 and b > 2) or (c > 3 and d > 4)`
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step s {
+                agent: a
+                when: x > 1 and y > 2 or z > 3 and w > 4
+            }
+        }
+    "#,
+    );
+    let when = f.workflows[0].steps[0].when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Or(parts) => {
+            assert_eq!(parts.len(), 2);
+            assert!(matches!(&parts[0], crate::ast::WhenExpr::And(p) if p.len() == 2));
+            assert!(matches!(&parts[1], crate::ast::WhenExpr::And(p) if p.len() == 2));
+        }
+        other => panic!("expected Or, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Closes #200

- `and` now binds tighter than `or` using proper recursive descent
- `a or b and c` parses as `a or (b and c)`
- Added 4 precedence tests