### PR TITLE
feat(parser): archetype/from agent templates

### DIFF
--- a/src/ast/agent.rs
+++ b/src/ast/agent.rs
@@ -27,9 +27,26 @@ pub struct Budget {
     pub span: Span,
 }
 
-/// A single `agent <name> { ... }` definition.
+/// A single `agent <name> { ... }` or `agent <name> from <archetype> { ... }` definition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AgentDef {
+    pub name: String,
+    /// Optional archetype this agent inherits from.
+    pub from: Option<String>,
+    pub model: Option<ValueExpr>,
+    pub can: Vec<Capability>,
+    pub cannot: Vec<Capability>,
+    pub budget: Option<Budget>,
+    pub guardrails: Option<GuardrailsDef>,
+    pub span: Span,
+}
+
+/// An `archetype <name> { ... }` template definition.
+///
+/// Archetypes define reusable agent templates. Agents can inherit from
+/// an archetype using `agent <name> from <archetype> { ... }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchetypeDef {
     pub name: String,
     pub model: Option<ValueExpr>,
     pub can: Vec<Capability>,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -40,6 +40,7 @@ pub struct ReinFile {
     pub defaults: Option<DefaultsDef>,
     pub providers: Vec<ProviderDef>,
     pub tools: Vec<ToolDef>,
+    pub archetypes: Vec<ArchetypeDef>,
     pub agents: Vec<AgentDef>,
     pub workflows: Vec<WorkflowDef>,
     pub types: Vec<TypeDef>,

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -68,7 +68,7 @@ fn budget_serializes() {
 
 #[test]
 fn agent_def_full_serializes() {
-    let agent = AgentDef {
+    let agent = AgentDef { from: None,
         name: "support_triage".to_string(),
         model: Some(ValueExpr::Literal("anthropic".into())),
         can: vec![Capability {
@@ -102,12 +102,12 @@ fn agent_def_full_serializes() {
 
 #[test]
 fn rein_file_roundtrips_via_json() {
-    let file = ReinFile {
+    let file = ReinFile { archetypes: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],
         tools: vec![],
-        agents: vec![AgentDef {
+        agents: vec![AgentDef { from: None,
             name: "bot".to_string(),
             model: None,
             can: vec![],
@@ -126,7 +126,7 @@ fn rein_file_roundtrips_via_json() {
 
 #[test]
 fn agent_def_minimal_model_none() {
-    let agent = AgentDef {
+    let agent = AgentDef { from: None,
         name: "minimal".to_string(),
         model: None,
         can: vec![],
@@ -223,7 +223,7 @@ fn workflow_roundtrips_via_json() {
 
 #[test]
 fn rein_file_with_workflows_roundtrips() {
-    let file = ReinFile {
+    let file = ReinFile { archetypes: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -5,6 +5,7 @@ use crate::ast::Span;
 pub enum TokenKind {
     // Keywords
     Agent,
+    Archetype,
     Can,
     Cannot,
     Model,
@@ -93,6 +94,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Dot => write!(f, "."),
             TokenKind::Comma => write!(f, ","),
             TokenKind::Agent => write!(f, "agent"),
+            TokenKind::Archetype => write!(f, "archetype"),
             TokenKind::Can => write!(f, "can"),
             TokenKind::Cannot => write!(f, "cannot"),
             TokenKind::Model => write!(f, "model"),
@@ -250,6 +252,7 @@ impl<'a> Lexer<'a> {
         let word = std::str::from_utf8(&self.src[start..end]).unwrap();
         let kind = match word {
             "agent" => TokenKind::Agent,
+            "archetype" => TokenKind::Archetype,
             "can" => TokenKind::Can,
             "cannot" => TokenKind::Cannot,
             "model" => TokenKind::Model,

--- a/src/parser/agent_parser.rs
+++ b/src/parser/agent_parser.rs
@@ -1,200 +1,34 @@
 use crate::ast::{
-    AgentDef, Budget, Capability, Constraint, DefaultsDef, GuardrailRule, GuardrailSection,
-    GuardrailsDef, ProviderDef, Span, ToolDef, ValueExpr,
+    AgentDef, ArchetypeDef, Budget, Capability, GuardrailRule, GuardrailSection, GuardrailsDef,
+    Span, ValueExpr,
 };
 use crate::lexer::TokenKind;
 
 use super::{ParseError, Parser};
 
 impl Parser {
-    pub(super) fn parse_defaults(&mut self) -> Result<DefaultsDef, ParseError> {
-        let start = self.current_span().start;
-        self.expect(&TokenKind::Defaults)?;
-        self.expect(&TokenKind::LBrace)?;
-
-        let mut model: Option<ValueExpr> = None;
-        let mut budget: Option<Budget> = None;
-        let (mut seen_model, mut seen_budget) = (false, false);
-
-        loop {
-            self.skip_comments();
-            match self.peek().clone() {
-                TokenKind::RBrace => {
-                    let end = self.current_span().end;
-                    self.advance();
-                    return Ok(DefaultsDef {
-                        model,
-                        budget,
-                        span: Span::new(start, end),
-                    });
-                }
-                TokenKind::Model => {
-                    if seen_model {
-                        return Err(ParseError::new(
-                            "duplicate field 'model' in defaults block",
-                            self.current_span(),
-                        ));
-                    }
-                    seen_model = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    model = Some(self.parse_value_expr()?);
-                }
-                TokenKind::Budget => {
-                    if seen_budget {
-                        return Err(ParseError::new(
-                            "duplicate field 'budget' in defaults block",
-                            self.current_span(),
-                        ));
-                    }
-                    seen_budget = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    budget = Some(self.parse_budget()?);
-                }
-                other => {
-                    return Err(ParseError::new(
-                        format!("unexpected field in defaults block: {other}"),
-                        self.current_span(),
-                    ));
-                }
-            }
-        }
-    }
-
-    pub(super) fn parse_provider(&mut self) -> Result<ProviderDef, ParseError> {
+    pub(super) fn parse_archetype(&mut self) -> Result<ArchetypeDef, ParseError> {
         self.skip_comments();
         let start = self.current_span().start;
 
-        self.expect(&TokenKind::Provider)?;
+        self.expect(&TokenKind::Archetype)?;
         let (name, _) = self.expect_ident()?;
         self.expect(&TokenKind::LBrace)?;
 
-        let mut model: Option<ValueExpr> = None;
-        let mut key: Option<ValueExpr> = None;
-        let mut seen_model = false;
-        let mut seen_key = false;
+        let (model, can, cannot, budget, guardrails) = self.parse_agent_body(&name)?;
 
-        loop {
-            self.skip_comments();
-            match self.peek().clone() {
-                TokenKind::RBrace => {
-                    let end = self.current_span().end;
-                    self.advance();
-                    return Ok(ProviderDef {
-                        name,
-                        model,
-                        key,
-                        span: Span::new(start, end),
-                    });
-                }
-                TokenKind::Model => {
-                    if seen_model {
-                        return Err(ParseError::new(
-                            format!("duplicate field 'model' in provider '{name}'"),
-                            self.current_span(),
-                        ));
-                    }
-                    seen_model = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    model = Some(self.parse_value_expr()?);
-                }
-                TokenKind::Key => {
-                    if seen_key {
-                        return Err(ParseError::new(
-                            format!("duplicate field 'key' in provider '{name}'"),
-                            self.current_span(),
-                        ));
-                    }
-                    seen_key = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    key = Some(self.parse_value_expr()?);
-                }
-                other => {
-                    return Err(ParseError::new(
-                        format!("unexpected field in provider '{name}': {other}"),
-                        self.current_span(),
-                    ));
-                }
-            }
-        }
-    }
+        let end = self.current_span().end;
+        self.advance(); // consume RBrace
 
-    pub(super) fn parse_tool(&mut self) -> Result<ToolDef, ParseError> {
-        self.skip_comments();
-        let start = self.current_span().start;
-
-        self.expect(&TokenKind::Tool)?;
-        let (name, _) = self.expect_ident()?;
-        self.expect(&TokenKind::LBrace)?;
-
-        let mut endpoint: Option<ValueExpr> = None;
-        let mut provider: Option<ValueExpr> = None;
-        let mut key: Option<ValueExpr> = None;
-        let mut seen_endpoint = false;
-        let mut seen_provider = false;
-        let mut seen_key = false;
-
-        loop {
-            self.skip_comments();
-            match self.peek().clone() {
-                TokenKind::RBrace => {
-                    let end = self.current_span().end;
-                    self.advance();
-                    return Ok(ToolDef {
-                        name,
-                        endpoint,
-                        provider,
-                        key,
-                        span: Span::new(start, end),
-                    });
-                }
-                TokenKind::Endpoint => {
-                    if seen_endpoint {
-                        return Err(ParseError::new(
-                            format!("duplicate field 'endpoint' in tool '{name}'"),
-                            self.current_span(),
-                        ));
-                    }
-                    seen_endpoint = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    endpoint = Some(self.parse_value_expr()?);
-                }
-                TokenKind::Provider => {
-                    if seen_provider {
-                        return Err(ParseError::new(
-                            format!("duplicate field 'provider' in tool '{name}'"),
-                            self.current_span(),
-                        ));
-                    }
-                    seen_provider = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    provider = Some(self.parse_value_expr()?);
-                }
-                TokenKind::Key => {
-                    if seen_key {
-                        return Err(ParseError::new(
-                            format!("duplicate field 'key' in tool '{name}'"),
-                            self.current_span(),
-                        ));
-                    }
-                    seen_key = true;
-                    self.advance();
-                    self.expect(&TokenKind::Colon)?;
-                    key = Some(self.parse_value_expr()?);
-                }
-                other => {
-                    return Err(ParseError::new(
-                        format!("unexpected field in tool '{name}': {other}"),
-                        self.current_span(),
-                    ));
-                }
-            }
-        }
+        Ok(ArchetypeDef {
+            name,
+            model,
+            can,
+            cannot,
+            budget,
+            guardrails,
+            span: Span::new(start, end),
+        })
     }
 
     pub(super) fn parse_agent(&mut self) -> Result<AgentDef, ParseError> {
@@ -203,8 +37,52 @@ impl Parser {
 
         self.expect(&TokenKind::Agent)?;
         let (name, _) = self.expect_ident()?;
+
+        // Optional `from <archetype>` clause
+        let from = if *self.peek() == TokenKind::From {
+            self.advance();
+            let (archetype_name, _) = self.expect_ident()?;
+            Some(archetype_name)
+        } else {
+            None
+        };
+
         self.expect(&TokenKind::LBrace)?;
 
+        let (model, can, cannot, budget, guardrails) = self.parse_agent_body(&name)?;
+
+        let end = self.current_span().end;
+        self.advance(); // consume RBrace
+
+        Ok(AgentDef {
+            name,
+            from,
+            model,
+            can,
+            cannot,
+            budget,
+            guardrails,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse the body fields shared by both `agent` and `archetype` blocks.
+    /// Expects the opening `{` has already been consumed.
+    /// Returns when `}` is encountered (but does NOT consume it).
+    #[allow(clippy::type_complexity)]
+    fn parse_agent_body(
+        &mut self,
+        name: &str,
+    ) -> Result<
+        (
+            Option<ValueExpr>,
+            Vec<Capability>,
+            Vec<Capability>,
+            Option<Budget>,
+            Option<GuardrailsDef>,
+        ),
+        ParseError,
+    > {
         let mut model: Option<ValueExpr> = None;
         let mut can: Vec<Capability> = Vec::new();
         let mut cannot: Vec<Capability> = Vec::new();
@@ -218,35 +96,24 @@ impl Parser {
             self.skip_comments();
             match self.peek().clone() {
                 TokenKind::RBrace => {
-                    let end = self.current_span().end;
-                    self.advance();
-                    return Ok(AgentDef {
-                        name,
-                        model,
-                        can,
-                        cannot,
-                        budget,
-                        guardrails,
-                        span: Span::new(start, end),
-                    });
+                    return Ok((model, can, cannot, budget, guardrails));
                 }
                 TokenKind::Model => {
                     if seen_model {
                         return Err(ParseError::new(
-                            format!("duplicate field 'model' in agent '{name}'"),
+                            format!("duplicate field 'model' in '{name}'"),
                             self.current_span(),
                         ));
                     }
                     seen_model = true;
                     self.advance();
                     self.expect(&TokenKind::Colon)?;
-                    let value = self.parse_value_expr()?;
-                    model = Some(value);
+                    model = Some(self.parse_value_expr()?);
                 }
                 TokenKind::Can => {
                     if seen_can {
                         return Err(ParseError::new(
-                            format!("duplicate field 'can' in agent '{name}'"),
+                            format!("duplicate field 'can' in '{name}'"),
                             self.current_span(),
                         ));
                     }
@@ -257,7 +124,7 @@ impl Parser {
                 TokenKind::Cannot => {
                     if seen_cannot {
                         return Err(ParseError::new(
-                            format!("duplicate field 'cannot' in agent '{name}'"),
+                            format!("duplicate field 'cannot' in '{name}'"),
                             self.current_span(),
                         ));
                     }
@@ -268,7 +135,7 @@ impl Parser {
                 TokenKind::Budget => {
                     if seen_budget {
                         return Err(ParseError::new(
-                            format!("duplicate field 'budget' in agent '{name}'"),
+                            format!("duplicate field 'budget' in '{name}'"),
                             self.current_span(),
                         ));
                     }
@@ -280,7 +147,7 @@ impl Parser {
                 TokenKind::Guardrails => {
                     if seen_guardrails {
                         return Err(ParseError::new(
-                            format!("duplicate field 'guardrails' in agent '{name}'"),
+                            format!("duplicate field 'guardrails' in '{name}'"),
                             self.current_span(),
                         ));
                     }
@@ -295,7 +162,7 @@ impl Parser {
                 }
                 other => {
                     return Err(ParseError::new(
-                        format!("unexpected token in agent body: {other}"),
+                        format!("unexpected token in body of '{name}': {other}"),
                         self.current_span(),
                     ));
                 }
@@ -393,81 +260,5 @@ impl Parser {
                 }
             }
         }
-    }
-
-    pub(super) fn parse_capability_list(&mut self) -> Result<Vec<Capability>, ParseError> {
-        self.expect(&TokenKind::LBracket)?;
-        let mut caps = Vec::new();
-        loop {
-            self.skip_comments();
-            match self.peek() {
-                TokenKind::RBracket => {
-                    self.advance();
-                    break;
-                }
-                TokenKind::Eof => {
-                    return Err(ParseError::new(
-                        "unexpected end of file: expected `]`",
-                        self.current_span(),
-                    ));
-                }
-                _ => caps.push(self.parse_capability()?),
-            }
-        }
-        Ok(caps)
-    }
-
-    fn parse_capability(&mut self) -> Result<Capability, ParseError> {
-        let start = self.current_span().start;
-        let (namespace, _) = self.expect_ident()?;
-        self.expect(&TokenKind::Dot)?;
-        let (action, _) = self.expect_ident()?;
-
-        // optional `up to $<amount>`
-        let constraint = if self.peek() == &TokenKind::Up {
-            self.advance();
-            self.expect(&TokenKind::To)?;
-            let (amount, symbol, _) = self.expect_currency()?;
-            let currency = match symbol {
-                '€' => "EUR",
-                '£' => "GBP",
-                '¥' => "JPY",
-                _ => "USD",
-            };
-            Some(Constraint::MonetaryCap {
-                amount,
-                currency: currency.to_string(),
-            })
-        } else {
-            None
-        };
-
-        let end = self.last_consumed_end;
-        Ok(Capability {
-            namespace,
-            action,
-            constraint,
-            span: Span::new(start, end),
-        })
-    }
-
-    pub(super) fn parse_budget(&mut self) -> Result<Budget, ParseError> {
-        let start = self.current_span().start;
-        let (amount, symbol, _) = self.expect_currency()?;
-        self.expect(&TokenKind::Per)?;
-        let (unit, _) = self.expect_ident()?;
-        let end = self.last_consumed_end;
-        let currency = match symbol {
-            '€' => "EUR",
-            '£' => "GBP",
-            '¥' => "JPY",
-            _ => "USD",
-        };
-        Ok(Budget {
-            amount,
-            currency: currency.to_string(),
-            unit,
-            span: Span::new(start, end),
-        })
     }
 }

--- a/src/parser/common_parser.rs
+++ b/src/parser/common_parser.rs
@@ -1,0 +1,274 @@
+use crate::ast::{
+    Budget, Capability, Constraint, DefaultsDef, ProviderDef, Span, ToolDef, ValueExpr,
+};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    pub(super) fn parse_defaults(&mut self) -> Result<DefaultsDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Defaults)?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut model: Option<ValueExpr> = None;
+        let mut budget: Option<Budget> = None;
+        let (mut seen_model, mut seen_budget) = (false, false);
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(DefaultsDef {
+                        model,
+                        budget,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Model => {
+                    if seen_model {
+                        return Err(ParseError::new(
+                            "duplicate field 'model' in defaults block",
+                            self.current_span(),
+                        ));
+                    }
+                    seen_model = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    model = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Budget => {
+                    if seen_budget {
+                        return Err(ParseError::new(
+                            "duplicate field 'budget' in defaults block",
+                            self.current_span(),
+                        ));
+                    }
+                    seen_budget = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    budget = Some(self.parse_budget()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected field in defaults block: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    pub(super) fn parse_provider(&mut self) -> Result<ProviderDef, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Provider)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut model: Option<ValueExpr> = None;
+        let mut key: Option<ValueExpr> = None;
+        let mut seen_model = false;
+        let mut seen_key = false;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(ProviderDef {
+                        name,
+                        model,
+                        key,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Model => {
+                    if seen_model {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'model' in provider '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_model = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    model = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Key => {
+                    if seen_key {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'key' in provider '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_key = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    key = Some(self.parse_value_expr()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected field in provider '{name}': {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    pub(super) fn parse_tool(&mut self) -> Result<ToolDef, ParseError> {
+        self.skip_comments();
+        let start = self.current_span().start;
+
+        self.expect(&TokenKind::Tool)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut endpoint: Option<ValueExpr> = None;
+        let mut provider: Option<ValueExpr> = None;
+        let mut key: Option<ValueExpr> = None;
+        let mut seen_endpoint = false;
+        let mut seen_provider = false;
+        let mut seen_key = false;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => {
+                    let end = self.current_span().end;
+                    self.advance();
+                    return Ok(ToolDef {
+                        name,
+                        endpoint,
+                        provider,
+                        key,
+                        span: Span::new(start, end),
+                    });
+                }
+                TokenKind::Endpoint => {
+                    if seen_endpoint {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'endpoint' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_endpoint = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    endpoint = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Provider => {
+                    if seen_provider {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'provider' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_provider = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    provider = Some(self.parse_value_expr()?);
+                }
+                TokenKind::Key => {
+                    if seen_key {
+                        return Err(ParseError::new(
+                            format!("duplicate field 'key' in tool '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    seen_key = true;
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    key = Some(self.parse_value_expr()?);
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected field in tool '{name}': {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+    }
+
+    pub(super) fn parse_capability_list(&mut self) -> Result<Vec<Capability>, ParseError> {
+        self.expect(&TokenKind::LBracket)?;
+        let mut caps = Vec::new();
+        loop {
+            self.skip_comments();
+            match self.peek() {
+                TokenKind::RBracket => {
+                    self.advance();
+                    break;
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file: expected `]`",
+                        self.current_span(),
+                    ));
+                }
+                _ => caps.push(self.parse_capability()?),
+            }
+        }
+        Ok(caps)
+    }
+
+    fn parse_capability(&mut self) -> Result<Capability, ParseError> {
+        let start = self.current_span().start;
+        let (namespace, _) = self.expect_ident()?;
+        self.expect(&TokenKind::Dot)?;
+        let (action, _) = self.expect_ident()?;
+
+        // optional `up to $<amount>`
+        let constraint = if self.peek() == &TokenKind::Up {
+            self.advance();
+            self.expect(&TokenKind::To)?;
+            let (amount, symbol, _) = self.expect_currency()?;
+            let currency = match symbol {
+                '€' => "EUR",
+                '£' => "GBP",
+                '¥' => "JPY",
+                _ => "USD",
+            };
+            Some(Constraint::MonetaryCap {
+                amount,
+                currency: currency.to_string(),
+            })
+        } else {
+            None
+        };
+
+        let end = self.last_consumed_end;
+        Ok(Capability {
+            namespace,
+            action,
+            constraint,
+            span: Span::new(start, end),
+        })
+    }
+
+    pub(super) fn parse_budget(&mut self) -> Result<Budget, ParseError> {
+        let start = self.current_span().start;
+        let (amount, symbol, _) = self.expect_currency()?;
+        self.expect(&TokenKind::Per)?;
+        let (unit, _) = self.expect_ident()?;
+        let end = self.last_consumed_end;
+        let currency = match symbol {
+            '€' => "EUR",
+            '£' => "GBP",
+            '¥' => "JPY",
+            _ => "USD",
+        };
+        Ok(Budget {
+            amount,
+            currency: currency.to_string(),
+            unit,
+            span: Span::new(start, end),
+        })
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,6 +2,7 @@ use crate::ast::{ReinFile, Span, ValueExpr};
 use crate::lexer::{Token, TokenKind, tokenize};
 
 mod agent_parser;
+mod common_parser;
 mod import_parser;
 mod step_parser;
 mod type_parser;
@@ -277,6 +278,7 @@ impl Parser {
         let mut defaults = None;
         let mut providers = Vec::new();
         let mut tools = Vec::new();
+        let mut archetypes = Vec::new();
         let mut agents = Vec::new();
         let mut workflows = Vec::new();
         let mut types = Vec::new();
@@ -294,13 +296,14 @@ impl Parser {
                 }
                 TokenKind::Provider => providers.push(self.parse_provider()?),
                 TokenKind::Tool => tools.push(self.parse_tool()?),
+                TokenKind::Archetype => archetypes.push(self.parse_archetype()?),
                 TokenKind::Agent => agents.push(self.parse_agent()?),
                 TokenKind::Workflow => workflows.push(self.parse_workflow()?),
                 TokenKind::Type => types.push(self.parse_type_def()?),
                 other => {
                     return Err(ParseError::new(
                         format!(
-                            "expected top-level declaration (defaults, provider, tool, agent, workflow, type), got {other}"
+                            "expected top-level declaration (defaults, provider, tool, archetype, agent, workflow, type), got {other}"
                         ),
                         self.current_span(),
                     ));
@@ -313,6 +316,7 @@ impl Parser {
             defaults,
             providers,
             tools,
+            archetypes,
             agents,
             workflows,
             types,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1805,3 +1805,79 @@ fn when_mixed_precedence_complex() {
         other => panic!("expected Or, got {other:?}"),
     }
 }
+
+// ── archetype/from tests ────────────────────────────────────────────────
+
+#[test]
+fn parse_archetype_basic() {
+    let f = parse_ok(
+        r#"
+        archetype base {
+            model: openai
+            can [zendesk.read_ticket]
+        }
+        agent helper from base {
+            budget: $0.05 per request
+        }
+        workflow w {
+            trigger: event
+            step s { agent: helper }
+        }
+    "#,
+    );
+    assert_eq!(f.archetypes.len(), 1);
+    assert_eq!(f.archetypes[0].name, "base");
+    assert_eq!(
+        f.archetypes[0].model.as_ref().unwrap().display_value(),
+        "openai"
+    );
+    assert_eq!(f.archetypes[0].can.len(), 1);
+
+    assert_eq!(f.agents.len(), 1);
+    assert_eq!(f.agents[0].name, "helper");
+    assert_eq!(f.agents[0].from.as_deref(), Some("base"));
+    assert!(f.agents[0].budget.is_some());
+}
+
+#[test]
+fn parse_agent_without_from() {
+    let f = parse_ok(
+        r#"
+        agent standalone { model: openai }
+        workflow w { trigger: event step s { agent: standalone } }
+    "#,
+    );
+    assert!(f.agents[0].from.is_none());
+}
+
+#[test]
+fn parse_archetype_empty_body() {
+    let f = parse_ok(
+        r#"
+        archetype empty {}
+        agent a from empty { model: openai }
+        workflow w { trigger: event step s { agent: a } }
+    "#,
+    );
+    assert_eq!(f.archetypes[0].name, "empty");
+    assert!(f.archetypes[0].model.is_none());
+}
+
+#[test]
+fn parse_archetype_with_guardrails() {
+    let f = parse_ok(
+        r#"
+        archetype guarded {
+            model: anthropic
+            guardrails {
+                output_filter {
+                    pii_detection: redact
+                }
+            }
+        }
+        agent bot from guarded {}
+        workflow w { trigger: event step s { agent: bot } }
+    "#,
+    );
+    assert!(f.archetypes[0].guardrails.is_some());
+}

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -11,7 +11,7 @@ fn make_agent(
     cannot: Vec<Capability>,
     budget_cents: Option<u64>,
 ) -> AgentDef {
-    AgentDef {
+    AgentDef { from: None,
         name: "test".to_string(),
         model: Some(ValueExpr::Literal("gpt-4o".into())),
         can,

--- a/src/runtime/interceptor/tests.rs
+++ b/src/runtime/interceptor/tests.rs
@@ -5,7 +5,7 @@ use crate::ast::ValueExpr;
 use crate::ast::{AgentDef, Capability, Constraint, Span};
 
 fn make_agent(can: Vec<Capability>, cannot: Vec<Capability>) -> AgentDef {
-    AgentDef {
+    AgentDef { from: None,
         name: "test_agent".to_string(),
         model: Some(ValueExpr::Literal("openai".into())),
         can,

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -32,7 +32,7 @@ mod permissions_tests {
     }
 
     fn agent(can: Vec<Capability>, cannot: Vec<Capability>) -> AgentDef {
-        AgentDef {
+        AgentDef { from: None,
             name: "test_agent".into(),
             model: None,
             can,

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -78,12 +78,12 @@ fn zero_budget_detected() {
     // We can't express $0 directly in the grammar, so we build the AST
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
-    let file = ReinFile {
+    let file = ReinFile { archetypes: vec![],
             imports: vec![],
         defaults: None,
         providers: vec![],
         tools: vec![],
-        agents: vec![AgentDef {
+        agents: vec![AgentDef { from: None,
             name: "bot".into(),
             model: Some(ValueExpr::Literal("anthropic".into())),
             can: vec![],


### PR DESCRIPTION
Closes #121

- `archetype base { model: openai, can [...] }`
- `agent x from base { budget: $0.05 per request }`
- New ArchetypeDef AST type, 'from' field on AgentDef
- Extracted common_parser.rs for shared parsing helpers