### PR TITLE
feat(validator): cross-reference validation between providers and agents

### DIFF
--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -57,6 +57,7 @@ pub fn validate(file: &ReinFile) -> Vec<Diagnostic> {
         check_duplicate_capabilities(agent, &mut diags);
         check_model_present(agent, &mut diags);
     }
+    check_agent_model_provider_refs(file, &mut diags);
     check_duplicate_workflow_names(file, &mut diags);
     for workflow in &file.workflows {
         check_workflow_stages_reference_agents(file, workflow, &mut diags);
@@ -350,6 +351,29 @@ fn check_provider_key_present(provider: &ProviderDef, diags: &mut Vec<Diagnostic
             format!("provider '{}' has no `key` field", provider.name),
             provider.span.clone(),
         ));
+    }
+}
+
+/// W006: agent model references a provider prefix that doesn't match any defined provider.
+fn check_agent_model_provider_refs(file: &ReinFile, diags: &mut Vec<Diagnostic>) {
+    use std::collections::HashSet;
+    let provider_names: HashSet<&str> = file.providers.iter().map(|p| p.name.as_str()).collect();
+
+    for agent in &file.agents {
+        if let Some(model_expr) = &agent.model
+            && let Some(model_str) = model_expr.as_literal()
+            && let Some((prefix, _)) = model_str.split_once('/')
+            && !provider_names.contains(prefix)
+        {
+            diags.push(Diagnostic::warning(
+                "W006",
+                format!(
+                    "agent '{}' model '{}' references unknown provider '{}'",
+                    agent.name, model_str, prefix
+                ),
+                agent.span.clone(),
+            ));
+        }
     }
 }
 

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -375,3 +375,38 @@ fn step_stage_name_collision_errors() {
     assert_eq!(errors.len(), 1);
     assert!(errors[0].message.contains("collides with stage"));
 }
+
+#[test]
+fn model_with_known_provider_prefix_no_warning() {
+    let diags = validate_src(
+        r#"
+        provider anthropic { key: "k" }
+        agent foo { model: "anthropic/claude-3" }
+    "#,
+    );
+    let w006: Vec<_> = diags.iter().filter(|d| d.code == "W006").collect();
+    assert!(w006.is_empty(), "expected no W006, got: {w006:?}");
+}
+
+#[test]
+fn model_with_unknown_provider_prefix_warns() {
+    let diags = validate_src(
+        r#"
+        agent foo { model: "unknown_provider/some-model" }
+    "#,
+    );
+    let w006: Vec<_> = diags.iter().filter(|d| d.code == "W006").collect();
+    assert_eq!(w006.len(), 1);
+    assert!(w006[0].message.contains("unknown_provider"));
+}
+
+#[test]
+fn model_without_slash_no_provider_warning() {
+    let diags = validate_src(
+        r#"
+        agent foo { model: "gpt-4o" }
+    "#,
+    );
+    let w006: Vec<_> = diags.iter().filter(|d| d.code == "W006").collect();
+    assert!(w006.is_empty());
+}


### PR DESCRIPTION
Adds W006: warns when agent model uses a provider/model format but the provider prefix doesn't match any defined provider.

Closes #177