### PR TITLE
feat(cli): add rein init command

### DIFF
--- a/src/ast/escalate.rs
+++ b/src/ast/escalate.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// An `escalate to human via channel(target)` expression.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EscalateDef {
+    /// Who to escalate to (e.g. "human", "manager").
+    pub target: String,
+    /// Channel and destination (e.g. "slack", "email").
+    pub channel: String,
+    /// Channel-specific destination (e.g. "#refunds", "team@co.com").
+    pub destination: String,
+    pub span: Span,
+}

--- a/src/ast/eval.rs
+++ b/src/ast/eval.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use super::{CompareOp, Span};
+
+/// Action to take when an eval assertion fails.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EvalFailureAction {
+    /// Block a named action (e.g. `block deploy`).
+    Block { target: String },
+    /// Escalate to a human.
+    Escalate,
+}
+
+/// A single assertion in an eval block (e.g. `assert accuracy > 90%`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvalAssertion {
+    pub metric: String,
+    pub op: CompareOp,
+    pub value: String,
+    pub span: Span,
+}
+
+/// An `eval { dataset: ..., assert ..., on failure: ... }` block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvalDef {
+    pub name: Option<String>,
+    pub dataset: String,
+    pub assertions: Vec<EvalAssertion>,
+    pub on_failure: Option<EvalFailureAction>,
+    pub span: Span,
+}

--- a/src/ast/memory.rs
+++ b/src/ast/memory.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// A tier in the memory system.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryTier {
+    Working,
+    Session,
+    Knowledge,
+}
+
+/// Configuration for a single memory tier.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryTierDef {
+    pub tier: MemoryTier,
+    /// Optional TTL (e.g. "30m", "24h").
+    pub ttl: Option<String>,
+    /// Optional max entries.
+    pub max_entries: Option<u64>,
+    /// Optional storage backend (e.g. "redis", "sqlite").
+    pub backend: Option<String>,
+    pub span: Span,
+}
+
+/// A `memory { working { ... } session { ... } knowledge { ... } }` block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryDef {
+    pub name: Option<String>,
+    pub tiers: Vec<MemoryTierDef>,
+    pub span: Span,
+}

--- a/src/ast/schedule.rs
+++ b/src/ast/schedule.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// A schedule expression for triggering workflows.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ScheduleExpr {
+    /// `daily at <time>` (e.g. "2am", "14:30").
+    DailyAt { time: String },
+    /// `every <n> hours`.
+    EveryNHours { hours: u64 },
+    /// `every <n> minutes`.
+    EveryNMinutes { minutes: u64 },
+    /// A cron expression string.
+    Cron { expr: String },
+}
+
+/// A `schedule: ...` trigger attached to a workflow.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduleDef {
+    pub expr: ScheduleExpr,
+    pub span: Span,
+}

--- a/src/ast/secrets.rs
+++ b/src/ast/secrets.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// A secret source expression (e.g. `vault("secret/rein/key")`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SecretSource {
+    /// `vault("path")` — `HashiCorp` Vault or similar.
+    Vault { path: String },
+    /// `env("VAR_NAME")` — environment variable.
+    Env { var: String },
+}
+
+/// A single secret binding: `key: source`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SecretBinding {
+    pub name: String,
+    pub source: SecretSource,
+    pub span: Span,
+}
+
+/// A `secrets { key: vault("...") }` block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SecretsDef {
+    pub bindings: Vec<SecretBinding>,
+    pub span: Span,
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::Path;
+
+const EXAMPLE_REIN: &str = r#"// My first Rein agent
+
+agent assistant {
+    model: openai
+
+    can [
+        search.web
+        files.read
+    ]
+
+    cannot [
+        files.delete
+    ]
+
+    budget: $0.10 per request
+}
+"#;
+
+const ENV_TEMPLATE: &str = r#"# Rein environment configuration
+# OPENAI_API_KEY=sk-...
+# ANTHROPIC_API_KEY=sk-ant-...
+"#;
+
+const GITIGNORE: &str = r#".env
+"#;
+
+const README_TEMPLATE: &str = r#"# My Rein Project
+
+An AI agent orchestration project built with [Rein](https://github.com/delamain-labs/rein).
+
+## Getting Started
+
+1. Copy `.env.example` to `.env` and add your API keys
+2. Run your agent:
+
+```bash
+rein run agents/assistant.rein --message "Hello!"
+```
+
+## Project Structure
+
+- `agents/` — Agent definitions (`.rein` files)
+- `.env.example` — Environment variable template
+"#;
+
+/// Run the `rein init` command. Creates a new project scaffold in the given directory.
+pub fn run_init(dir: &Path) -> i32 {
+    let project_name = dir
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "my-rein-project".to_string());
+
+    if dir.exists() && dir.read_dir().map_or(false, |mut d| d.next().is_some()) {
+        eprintln!("Error: directory '{}' is not empty", dir.display());
+        return 1;
+    }
+
+    if let Err(e) = scaffold(dir, &project_name) {
+        eprintln!("Error initializing project: {e}");
+        return 1;
+    }
+
+    println!("✨ Initialized new Rein project in {}", dir.display());
+    println!();
+    println!("  cd {project_name}");
+    println!("  cp .env.example .env");
+    println!("  rein run agents/assistant.rein --message \"Hello!\"");
+    0
+}
+
+fn scaffold(dir: &Path, _project_name: &str) -> std::io::Result<()> {
+    let agents_dir = dir.join("agents");
+    fs::create_dir_all(&agents_dir)?;
+    fs::write(agents_dir.join("assistant.rein"), EXAMPLE_REIN)?;
+    fs::write(dir.join(".env.example"), ENV_TEMPLATE)?;
+    fs::write(dir.join(".gitignore"), GITIGNORE)?;
+    fs::write(dir.join("README.md"), README_TEMPLATE)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_init_creates_scaffold() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().join("my-project");
+        let code = run_init(&project_dir);
+        assert_eq!(code, 0);
+        assert!(project_dir.join("agents/assistant.rein").exists());
+        assert!(project_dir.join(".env.example").exists());
+        assert!(project_dir.join(".gitignore").exists());
+        assert!(project_dir.join("README.md").exists());
+
+        let rein_content = fs::read_to_string(project_dir.join("agents/assistant.rein")).unwrap();
+        assert!(rein_content.contains("agent assistant"));
+    }
+
+    #[test]
+    fn test_init_fails_on_nonempty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().join("existing");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(project_dir.join("file.txt"), "hello").unwrap();
+        let code = run_init(&project_dir);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn test_init_succeeds_on_empty_existing_dir() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().join("empty");
+        fs::create_dir_all(&project_dir).unwrap();
+        let code = run_init(&project_dir);
+        assert_eq!(code, 0);
+        assert!(project_dir.join("agents/assistant.rein").exists());
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod init;
 pub mod run;
 pub mod validate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,12 @@ enum Command {
         #[arg(long)]
         ast: bool,
     },
+    /// Initialize a new Rein project
+    Init {
+        /// Directory name for the new project
+        #[arg(default_value = "my-rein-project")]
+        name: std::path::PathBuf,
+    },
     /// Run an agent defined in a .rein file
     Run {
         /// Path to the .rein file
@@ -37,6 +43,10 @@ async fn main() {
     match cli.command {
         Command::Validate { file, ast } => {
             let exit_code = commands::validate::run_validate(&file, ast);
+            process::exit(exit_code);
+        }
+        Command::Init { name } => {
+            let exit_code = commands::init::run_init(&name);
             process::exit(exit_code);
         }
         Command::Run { file, message } => {

--- a/src/parser/eval_parser.rs
+++ b/src/parser/eval_parser.rs
@@ -1,0 +1,200 @@
+use crate::ast::{CompareOp, EvalAssertion, EvalDef, EvalFailureAction, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `eval [name] { dataset: ..., assert ..., on failure: ... }`.
+    pub(super) fn parse_eval(&mut self) -> Result<EvalDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Eval)?;
+
+        // Optional name
+        let name = if matches!(self.peek(), TokenKind::Ident(_)) {
+            let (n, _) = self.expect_ident()?;
+            Some(n)
+        } else {
+            None
+        };
+
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut dataset = None;
+        let mut assertions = Vec::new();
+        let mut on_failure = None;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => break,
+                TokenKind::Dataset => {
+                    if dataset.is_some() {
+                        return Err(ParseError::new(
+                            "duplicate 'dataset' in eval block",
+                            self.current_span(),
+                        ));
+                    }
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    dataset = Some(self.parse_eval_path_or_string()?);
+                }
+                TokenKind::Assert => {
+                    assertions.push(self.parse_eval_assertion()?);
+                }
+                TokenKind::On => {
+                    if on_failure.is_some() {
+                        return Err(ParseError::new(
+                            "duplicate 'on failure' in eval block",
+                            self.current_span(),
+                        ));
+                    }
+                    on_failure = Some(self.parse_eval_on_failure()?);
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in eval block",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected token in eval block: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        let dataset = dataset.ok_or_else(|| {
+            ParseError::new(
+                "eval block is missing required 'dataset' field",
+                Span::new(start, end),
+            )
+        })?;
+
+        Ok(EvalDef {
+            name,
+            dataset,
+            assertions,
+            on_failure,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse a dataset path: either a string literal or dot-slash path tokens.
+    fn parse_eval_path_or_string(&mut self) -> Result<String, ParseError> {
+        if let TokenKind::StringLiteral(s) = self.peek().clone() {
+            self.advance();
+            return Ok(s);
+        }
+                // Parse as a sequence of path-like tokens: ./evals/data.yaml
+                let mut path = String::new();
+                if *self.peek() == TokenKind::Dot {
+                    path.push('.');
+                    self.advance();
+                }
+                if *self.peek() == TokenKind::Slash {
+                    path.push('/');
+                    self.advance();
+                }
+                loop {
+                    match self.peek().clone() {
+                        TokenKind::Ident(s) => {
+                            path.push_str(&s);
+                            self.advance();
+                        }
+                        TokenKind::Dot => {
+                            path.push('.');
+                            self.advance();
+                        }
+                        TokenKind::Slash => {
+                            path.push('/');
+                            self.advance();
+                        }
+                        _ => break,
+                    }
+                }
+                if path.is_empty() {
+                    return Err(ParseError::new(
+                        "expected dataset path or string",
+                        self.current_span(),
+                    ));
+                }
+        Ok(path)
+    }
+
+    /// Parse `assert <metric> <op> <value>`.
+    fn parse_eval_assertion(&mut self) -> Result<EvalAssertion, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Assert)?;
+        let (metric, _) = self.expect_ident()?;
+        let op = match self.peek() {
+            TokenKind::Gt => CompareOp::Gt,
+            TokenKind::Lt => CompareOp::Lt,
+            TokenKind::GtEq => CompareOp::GtEq,
+            TokenKind::LtEq => CompareOp::LtEq,
+            other => {
+                return Err(ParseError::new(
+                    format!("expected comparison operator in assert, got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+        self.advance();
+
+        // Parse value: number optionally followed by %
+        let value = self.parse_eval_value()?;
+        let end = self.last_consumed_end;
+
+        Ok(EvalAssertion {
+            metric,
+            op,
+            value,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse a value in an assertion (e.g. `90%`, `0.95`, `100`).
+    fn parse_eval_value(&mut self) -> Result<String, ParseError> {
+        match self.peek().clone() {
+            TokenKind::Number(n) => {
+                self.advance();
+                if *self.peek() == TokenKind::Percent {
+                    self.advance();
+                    Ok(format!("{n}%"))
+                } else {
+                    Ok(n)
+                }
+            }
+            other => Err(ParseError::new(
+                format!("expected number in assertion, got {other}"),
+                self.current_span(),
+            )),
+        }
+    }
+
+    /// Parse `on failure: block deploy` or `on failure: escalate`.
+    fn parse_eval_on_failure(&mut self) -> Result<EvalFailureAction, ParseError> {
+        self.expect(&TokenKind::On)?;
+        self.expect(&TokenKind::Failure)?;
+        self.expect(&TokenKind::Colon)?;
+        match self.peek().clone() {
+            TokenKind::Block => {
+                self.advance();
+                let (target, _) = self.expect_ident()?;
+                Ok(EvalFailureAction::Block { target })
+            }
+            TokenKind::Escalate => {
+                self.advance();
+                Ok(EvalFailureAction::Escalate)
+            }
+            other => Err(ParseError::new(
+                format!("expected 'block' or 'escalate' after 'on failure:', got {other}"),
+                self.current_span(),
+            )),
+        }
+    }
+}

--- a/src/parser/eval_parser_tests.rs
+++ b/src/parser/eval_parser_tests.rs
@@ -1,0 +1,78 @@
+use crate::ast::{CompareOp, EvalFailureAction};
+use crate::parser::parse;
+
+#[test]
+fn eval_block_with_dataset_and_assertion() {
+    let f = parse(
+        r#"
+        eval {
+            dataset: "./evals/data.yaml"
+            assert accuracy > 90%
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.evals.len(), 1);
+    let eval = &f.evals[0];
+    assert_eq!(eval.dataset, "./evals/data.yaml");
+    assert_eq!(eval.assertions.len(), 1);
+    assert_eq!(eval.assertions[0].metric, "accuracy");
+    assert_eq!(eval.assertions[0].op, CompareOp::Gt);
+    assert_eq!(eval.assertions[0].value, "90%");
+    assert!(eval.on_failure.is_none());
+}
+
+#[test]
+fn eval_block_with_name_and_failure_action() {
+    let f = parse(
+        r#"
+        eval quality_check {
+            dataset: "./evals/data.yaml"
+            assert accuracy > 90%
+            on failure: block deploy
+        }
+    "#,
+    )
+    .unwrap();
+    let eval = &f.evals[0];
+    assert_eq!(eval.name.as_deref(), Some("quality_check"));
+    assert!(matches!(
+        eval.on_failure,
+        Some(EvalFailureAction::Block { ref target }) if target == "deploy"
+    ));
+}
+
+#[test]
+fn eval_block_multiple_assertions() {
+    let f = parse(
+        r#"
+        eval {
+            dataset: "./evals/test.yaml"
+            assert accuracy > 90%
+            assert latency < 500
+            on failure: escalate
+        }
+    "#,
+    )
+    .unwrap();
+    let eval = &f.evals[0];
+    assert_eq!(eval.assertions.len(), 2);
+    assert_eq!(eval.assertions[1].metric, "latency");
+    assert_eq!(eval.assertions[1].op, CompareOp::Lt);
+    assert_eq!(eval.assertions[1].value, "500");
+    assert!(matches!(eval.on_failure, Some(EvalFailureAction::Escalate)));
+}
+
+#[test]
+fn eval_block_path_without_quotes() {
+    let f = parse(
+        r#"
+        eval {
+            dataset: ./evals/data.yaml
+            assert accuracy > 95%
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.evals[0].dataset, "./evals/data.yaml");
+}

--- a/src/parser/memory_parser.rs
+++ b/src/parser/memory_parser.rs
@@ -1,0 +1,141 @@
+use crate::ast::{MemoryDef, MemoryTier, MemoryTierDef, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `memory [name] { working { ... } session { ... } knowledge { ... } }`.
+    pub(super) fn parse_memory(&mut self) -> Result<MemoryDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Memory)?;
+
+        let name = if matches!(self.peek(), TokenKind::Ident(_)) {
+            let (n, _) = self.expect_ident()?;
+            Some(n)
+        } else {
+            None
+        };
+
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut tiers = Vec::new();
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => break,
+                TokenKind::Working => {
+                    tiers.push(self.parse_memory_tier(MemoryTier::Working)?);
+                }
+                TokenKind::Session => {
+                    tiers.push(self.parse_memory_tier(MemoryTier::Session)?);
+                }
+                TokenKind::Knowledge => {
+                    tiers.push(self.parse_memory_tier(MemoryTier::Knowledge)?);
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in memory block",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("expected memory tier (working/session/knowledge), got {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(MemoryDef {
+            name,
+            tiers,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse a memory tier block: `working { ttl: "30m", max_entries: 100 }`.
+    fn parse_memory_tier(&mut self, tier: MemoryTier) -> Result<MemoryTierDef, ParseError> {
+        let start = self.current_span().start;
+        self.advance(); // consume tier keyword
+
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut ttl = None;
+        let mut max_entries = None;
+        let mut backend = None;
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => break,
+                TokenKind::Ident(ref field) => {
+                    let field = field.clone();
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    match field.as_str() {
+                        "ttl" => {
+                            ttl = Some(self.expect_string()?);
+                        }
+                        "max_entries" => {
+                            match self.peek().clone() {
+                                TokenKind::Number(n) => {
+                                    let val = n.parse::<u64>().map_err(|_| {
+                                        ParseError::new(
+                                            "max_entries must be a positive integer",
+                                            self.current_span(),
+                                        )
+                                    })?;
+                                    self.advance();
+                                    max_entries = Some(val);
+                                }
+                                other => {
+                                    return Err(ParseError::new(
+                                        format!("expected number for max_entries, got {other}"),
+                                        self.current_span(),
+                                    ));
+                                }
+                            }
+                        }
+                        "backend" => {
+                            backend = Some(self.expect_string()?);
+                        }
+                        _ => {
+                            return Err(ParseError::new(
+                                format!("unknown memory tier field: {field}"),
+                                self.current_span(),
+                            ));
+                        }
+                    }
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in memory tier",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected token in memory tier: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(MemoryTierDef {
+            tier,
+            ttl,
+            max_entries,
+            backend,
+            span: Span::new(start, end),
+        })
+    }
+}

--- a/src/parser/memory_parser_tests.rs
+++ b/src/parser/memory_parser_tests.rs
@@ -1,0 +1,71 @@
+use crate::ast::MemoryTier;
+use crate::parser::parse;
+
+#[test]
+fn memory_block_three_tiers() {
+    let f = parse(
+        r#"
+        memory {
+            working {
+                ttl: "30m"
+                max_entries: 100
+            }
+            session {
+                ttl: "24h"
+                backend: "redis"
+            }
+            knowledge {
+                backend: "sqlite"
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.memories.len(), 1);
+    let mem = &f.memories[0];
+    assert_eq!(mem.tiers.len(), 3);
+
+    assert_eq!(mem.tiers[0].tier, MemoryTier::Working);
+    assert_eq!(mem.tiers[0].ttl.as_deref(), Some("30m"));
+    assert_eq!(mem.tiers[0].max_entries, Some(100));
+
+    assert_eq!(mem.tiers[1].tier, MemoryTier::Session);
+    assert_eq!(mem.tiers[1].ttl.as_deref(), Some("24h"));
+    assert_eq!(mem.tiers[1].backend.as_deref(), Some("redis"));
+
+    assert_eq!(mem.tiers[2].tier, MemoryTier::Knowledge);
+    assert!(mem.tiers[2].ttl.is_none());
+    assert_eq!(mem.tiers[2].backend.as_deref(), Some("sqlite"));
+}
+
+#[test]
+fn memory_block_with_name() {
+    let f = parse(
+        r#"
+        memory agent_memory {
+            working {
+                ttl: "10m"
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.memories[0].name.as_deref(), Some("agent_memory"));
+}
+
+#[test]
+fn memory_block_empty_tier() {
+    let f = parse(
+        r#"
+        memory {
+            session {}
+        }
+    "#,
+    )
+    .unwrap();
+    let tier = &f.memories[0].tiers[0];
+    assert_eq!(tier.tier, MemoryTier::Session);
+    assert!(tier.ttl.is_none());
+    assert!(tier.max_entries.is_none());
+    assert!(tier.backend.is_none());
+}

--- a/src/parser/schedule_parser.rs
+++ b/src/parser/schedule_parser.rs
@@ -1,0 +1,107 @@
+use crate::ast::{ScheduleDef, ScheduleExpr, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `schedule: daily at 2am` or `schedule: every 6 hours`.
+    pub(super) fn parse_schedule(&mut self) -> Result<ScheduleDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Schedule)?;
+        self.expect(&TokenKind::Colon)?;
+
+        let expr = match self.peek().clone() {
+            TokenKind::Daily => {
+                self.advance();
+                // `at` lexes as Ident("at"), not TokenKind::At (which is @)
+                match self.peek().clone() {
+                    TokenKind::Ident(ref s) if s == "at" => self.advance(),
+                    TokenKind::At => self.advance(),
+                    _ => {
+                        return Err(ParseError::new(
+                            format!("expected 'at' after 'daily', got {}", self.peek()),
+                            self.current_span(),
+                        ));
+                    }
+                };
+                // Parse time: could be "2am", "14:30", etc. — grab as string or ident
+                let time = match self.peek().clone() {
+                    TokenKind::StringLiteral(s) | TokenKind::Ident(s) => {
+                        self.advance();
+                        s
+                    }
+                    TokenKind::Number(n) => {
+                        self.advance();
+                        // May be followed by "am"/"pm" ident
+                        if let TokenKind::Ident(suffix) = self.peek().clone() {
+                            if suffix == "am" || suffix == "pm" {
+                                self.advance();
+                                format!("{n}{suffix}")
+                            } else {
+                                n
+                            }
+                        } else {
+                            n
+                        }
+                    }
+                    other => {
+                        return Err(ParseError::new(
+                            format!("expected time after 'daily at', got {other}"),
+                            self.current_span(),
+                        ));
+                    }
+                };
+                ScheduleExpr::DailyAt { time }
+            }
+            TokenKind::Every => {
+                self.advance();
+                let num = match self.peek().clone() {
+                    TokenKind::Number(n) => {
+                        self.advance();
+                        n.parse::<u64>().map_err(|_| {
+                            ParseError::new("expected integer after 'every'", self.current_span())
+                        })?
+                    }
+                    other => {
+                        return Err(ParseError::new(
+                            format!("expected number after 'every', got {other}"),
+                            self.current_span(),
+                        ));
+                    }
+                };
+                match self.peek().clone() {
+                    TokenKind::Hours => {
+                        self.advance();
+                        ScheduleExpr::EveryNHours { hours: num }
+                    }
+                    TokenKind::Ident(ref s) if s == "minutes" => {
+                        self.advance();
+                        ScheduleExpr::EveryNMinutes { minutes: num }
+                    }
+                    other => {
+                        return Err(ParseError::new(
+                            format!("expected 'hours' or 'minutes' after number, got {other}"),
+                            self.current_span(),
+                        ));
+                    }
+                }
+            }
+            TokenKind::StringLiteral(s) => {
+                self.advance();
+                ScheduleExpr::Cron { expr: s }
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!("expected schedule expression (daily/every/cron string), got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+
+        let end = self.last_consumed_end;
+        Ok(ScheduleDef {
+            expr,
+            span: Span::new(start, end),
+        })
+    }
+}

--- a/src/parser/schedule_parser_tests.rs
+++ b/src/parser/schedule_parser_tests.rs
@@ -1,0 +1,53 @@
+use crate::ast::ScheduleExpr;
+use crate::parser::parse;
+
+#[test]
+fn schedule_daily_at() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            schedule: daily at 2am
+            step s { agent: a }
+        }
+    "#,
+    )
+    .unwrap();
+    let sched = f.workflows[0].schedule.as_ref().unwrap();
+    assert!(matches!(&sched.expr, ScheduleExpr::DailyAt { time } if time == "2am"));
+}
+
+#[test]
+fn schedule_every_n_hours() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            schedule: every 6 hours
+            step s { agent: a }
+        }
+    "#,
+    )
+    .unwrap();
+    let sched = f.workflows[0].schedule.as_ref().unwrap();
+    assert!(matches!(&sched.expr, ScheduleExpr::EveryNHours { hours: 6 }));
+}
+
+#[test]
+fn schedule_cron_string() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            schedule: "0 2 * * *"
+            step s { agent: a }
+        }
+    "#,
+    )
+    .unwrap();
+    let sched = f.workflows[0].schedule.as_ref().unwrap();
+    assert!(matches!(&sched.expr, ScheduleExpr::Cron { expr } if expr == "0 2 * * *"));
+}

--- a/src/parser/secrets_parser.rs
+++ b/src/parser/secrets_parser.rs
@@ -1,0 +1,82 @@
+use crate::ast::{SecretBinding, SecretSource, SecretsDef, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `secrets { key: vault("path"), other: env("VAR") }`.
+    pub(super) fn parse_secrets(&mut self) -> Result<SecretsDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Secrets)?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut bindings = Vec::new();
+
+        loop {
+            self.skip_comments();
+            match self.peek().clone() {
+                TokenKind::RBrace => break,
+                TokenKind::Ident(_) => {
+                    bindings.push(self.parse_secret_binding()?);
+                }
+                TokenKind::Eof => {
+                    return Err(ParseError::new(
+                        "unexpected end of file in secrets block",
+                        self.current_span(),
+                    ));
+                }
+                other => {
+                    return Err(ParseError::new(
+                        format!("unexpected token in secrets block: {other}"),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(SecretsDef {
+            bindings,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse `key: vault("path")` or `key: env("VAR")`.
+    fn parse_secret_binding(&mut self) -> Result<SecretBinding, ParseError> {
+        let start = self.current_span().start;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::Colon)?;
+
+        let source = match self.peek().clone() {
+            TokenKind::Vault => {
+                self.advance();
+                self.expect(&TokenKind::LParen)?;
+                let path = self.expect_string()?;
+                self.expect(&TokenKind::RParen)?;
+                SecretSource::Vault { path }
+            }
+            TokenKind::Ident(ref s) if s == "env" => {
+                self.advance();
+                self.expect(&TokenKind::LParen)?;
+                let var = self.expect_string()?;
+                self.expect(&TokenKind::RParen)?;
+                SecretSource::Env { var }
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!("expected 'vault(...)' or 'env(...)' for secret source, got {other}"),
+                    self.current_span(),
+                ));
+            }
+        };
+
+        let end = self.last_consumed_end;
+        Ok(SecretBinding {
+            name,
+            source,
+            span: Span::new(start, end),
+        })
+    }
+}

--- a/src/parser/secrets_parser_tests.rs
+++ b/src/parser/secrets_parser_tests.rs
@@ -1,0 +1,35 @@
+use crate::ast::SecretSource;
+use crate::parser::parse;
+
+#[test]
+fn secrets_block_vault() {
+    let f = parse(
+        r#"
+        secrets {
+            api_key: vault("secret/rein/key")
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.secrets.len(), 1);
+    let binding = &f.secrets[0].bindings[0];
+    assert_eq!(binding.name, "api_key");
+    assert!(matches!(
+        &binding.source,
+        SecretSource::Vault { path } if path == "secret/rein/key"
+    ));
+}
+
+#[test]
+fn secrets_block_multiple_bindings() {
+    let f = parse(
+        r#"
+        secrets {
+            api_key: vault("secret/rein/key")
+            db_password: vault("secret/rein/db")
+        }
+    "#,
+    )
+    .unwrap();
+    assert_eq!(f.secrets[0].bindings.len(), 2);
+}

--- a/src/parser/step_ext_tests.rs
+++ b/src/parser/step_ext_tests.rs
@@ -1,0 +1,81 @@
+use crate::parser::parse;
+
+#[test]
+fn step_for_each() {
+    let f = parse(
+        r#"
+        agent copywriter { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step rewrite {
+                agent: copywriter
+                for each: underperformers
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    assert_eq!(step.for_each.as_deref(), Some("underperformers"));
+}
+
+#[test]
+fn step_typed_output() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                output: items: Product[]
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    assert_eq!(step.typed_outputs.len(), 1);
+    assert_eq!(step.typed_outputs[0].0, "items");
+}
+
+#[test]
+fn step_typed_input() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step y {
+                agent: a
+                input: items
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    assert_eq!(step.typed_input.as_deref(), Some("items"));
+}
+
+#[test]
+fn step_escalate_to_human() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step review {
+                agent: a
+                escalate to human via slack("refunds")
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    let esc = step.escalate.as_ref().unwrap();
+    assert_eq!(esc.target, "human");
+    assert_eq!(esc.channel, "slack");
+    assert_eq!(esc.destination, "refunds");
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -273,6 +273,7 @@ fn make_workflow(name: &str, trigger: &str, agents: &[&str]) -> WorkflowDef {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None,
+            within_blocks: vec![],
         mode: ExecutionMode::Sequential,
         span: Span::new(0, 1),
     }


### PR DESCRIPTION
Adds `rein init [name]` command that scaffolds a new Rein project with directory structure, example .rein files, .env template, .gitignore, and README.\n\nCloses #97