### PR TITLE
feat(config): implement rein.toml project configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "wiremock",
 ]
 
@@ -1258,6 +1259,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1463,6 +1473,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1914,6 +1965,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.12", features = ["json"] }
 dotenvy = "0.15"
 async-trait = "0.1.89"
 regex = "1.12.3"
+toml = "0.8"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -24,6 +24,21 @@ const ENV_TEMPLATE: &str = r#"# Rein environment configuration
 # ANTHROPIC_API_KEY=sk-ant-...
 "#;
 
+const REIN_TOML_TEMPLATE: &str = r#"[project]
+name = "{name}"
+version = "0.1.0"
+
+[runtime]
+default_model = "gpt-4o"
+timeout_secs = 30
+max_retries = 3
+log_level = "info"
+
+[dev]
+watch = false
+hot_reload = false
+"#;
+
 const GITIGNORE: &str = r#".env
 "#;
 
@@ -71,13 +86,17 @@ pub fn run_init(dir: &Path) -> i32 {
     0
 }
 
-fn scaffold(dir: &Path, _project_name: &str) -> std::io::Result<()> {
+fn scaffold(dir: &Path, project_name: &str) -> std::io::Result<()> {
     let agents_dir = dir.join("agents");
     fs::create_dir_all(&agents_dir)?;
     fs::write(agents_dir.join("assistant.rein"), EXAMPLE_REIN)?;
     fs::write(dir.join(".env.example"), ENV_TEMPLATE)?;
     fs::write(dir.join(".gitignore"), GITIGNORE)?;
     fs::write(dir.join("README.md"), README_TEMPLATE)?;
+    fs::write(
+        dir.join("rein.toml"),
+        REIN_TOML_TEMPLATE.replace("{name}", project_name),
+    )?;
     Ok(())
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,9 @@
+use serde::Deserialize;
 use std::env;
+use std::path::Path;
 use std::time::Duration;
 
-/// Runtime configuration loaded from environment variables and `.env` files.
+/// Runtime configuration loaded from environment variables, `.env`, and `rein.toml`.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// `OpenAI` API key (from the `OPENAI_API_KEY` env var).
@@ -12,25 +14,149 @@ pub struct Config {
     pub default_model: String,
     /// HTTP request timeout.
     pub request_timeout: Duration,
+    /// Project-level settings from `rein.toml`.
+    pub project: ProjectConfig,
+}
+
+/// Deserialized `rein.toml` file.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ReinToml {
+    pub project: ProjectSection,
+    pub runtime: RuntimeSection,
+    pub registry: RegistrySection,
+    pub deploy: DeploySection,
+    pub observability: ObservabilitySection,
+    pub dev: DevSection,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ProjectSection {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+}
+
+impl Default for ProjectSection {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            version: "0.1.0".to_string(),
+            description: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct RuntimeSection {
+    pub default_model: Option<String>,
+    pub timeout_secs: Option<u64>,
+    pub max_retries: u32,
+    pub log_level: String,
+}
+
+impl Default for RuntimeSection {
+    fn default() -> Self {
+        Self {
+            default_model: None,
+            timeout_secs: None,
+            max_retries: 3,
+            log_level: "info".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct RegistrySection {
+    pub url: Option<String>,
+    pub token_env: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct DeploySection {
+    pub target: Option<String>,
+    pub region: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ObservabilitySection {
+    pub trace_output: Option<String>,
+    pub metrics_endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct DevSection {
+    pub watch: bool,
+    pub hot_reload: bool,
+}
+
+/// Resolved project configuration (merged from `rein.toml`).
+#[derive(Debug, Clone, Default)]
+pub struct ProjectConfig {
+    pub name: String,
+    pub version: String,
+    pub max_retries: u32,
+    pub log_level: String,
+    pub trace_output: Option<String>,
 }
 
 impl Config {
-    /// Load configuration from environment variables.
-    /// Attempts to load `.env` file first (silently ignores if missing).
+    /// Load configuration from `rein.toml`, environment variables, and `.env`.
     pub fn load() -> Self {
-        // Load .env file if present (ignore errors)
+        Self::load_from_dir(Path::new("."))
+    }
+
+    /// Load configuration from a specific directory.
+    pub fn load_from_dir(dir: &Path) -> Self {
+        // Load .env file if present
         let _ = dotenvy::dotenv();
+
+        // Load rein.toml if present
+        let toml_config = Self::load_toml(dir);
+
+        let default_model = toml_config
+            .runtime
+            .default_model
+            .clone()
+            .or_else(|| env::var("REIN_DEFAULT_MODEL").ok())
+            .unwrap_or_else(|| "gpt-4o".to_string());
+
+        let timeout = toml_config
+            .runtime
+            .timeout_secs
+            .or_else(|| {
+                env::var("REIN_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+            })
+            .unwrap_or(30);
 
         Self {
             openai_api_key: env::var("OPENAI_API_KEY").ok(),
             anthropic_api_key: env::var("ANTHROPIC_API_KEY").ok(),
-            default_model: env::var("REIN_DEFAULT_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()),
-            request_timeout: Duration::from_secs(
-                env::var("REIN_TIMEOUT_SECS")
-                    .ok()
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(30),
-            ),
+            default_model,
+            request_timeout: Duration::from_secs(timeout),
+            project: ProjectConfig {
+                name: toml_config.project.name,
+                version: toml_config.project.version,
+                max_retries: toml_config.runtime.max_retries,
+                log_level: toml_config.runtime.log_level,
+                trace_output: toml_config.observability.trace_output,
+            },
+        }
+    }
+
+    fn load_toml(dir: &Path) -> ReinToml {
+        let path = dir.join("rein.toml");
+        match std::fs::read_to_string(&path) {
+            Ok(content) => toml::from_str(&content).unwrap_or_default(),
+            Err(_) => ReinToml::default(),
         }
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,9 +1,20 @@
 use super::*;
 use std::time::Duration;
+use tempfile::TempDir;
 
 // Note: env::set_var/remove_var are unsafe in Rust 2024 edition because
 // they can cause data races in multithreaded programs. In tests, we accept
 // this risk since tests are the only place we need to manipulate env vars.
+
+fn make_config(openai: Option<&str>, anthropic: Option<&str>) -> Config {
+    Config {
+        openai_api_key: openai.map(String::from),
+        anthropic_api_key: anthropic.map(String::from),
+        default_model: "gpt-4o".to_string(),
+        request_timeout: Duration::from_secs(30),
+        project: ProjectConfig::default(),
+    }
+}
 
 #[test]
 fn default_model_is_gpt4o() {
@@ -21,34 +32,99 @@ fn default_timeout_is_30_seconds() {
 
 #[test]
 fn has_openai_key_false_when_missing() {
-    // This test verifies the helper method, not env loading
-    let config = Config {
-        openai_api_key: None,
-        anthropic_api_key: None,
-        default_model: "gpt-4o".to_string(),
-        request_timeout: Duration::from_secs(30),
-    };
+    let config = make_config(None, None);
     assert!(!config.has_openai_key());
 }
 
 #[test]
 fn has_openai_key_false_when_empty() {
-    let config = Config {
-        openai_api_key: Some(String::new()),
-        anthropic_api_key: None,
-        default_model: "gpt-4o".to_string(),
-        request_timeout: Duration::from_secs(30),
-    };
+    let config = make_config(Some(""), None);
     assert!(!config.has_openai_key());
 }
 
 #[test]
 fn has_openai_key_true_when_set() {
-    let config = Config {
-        openai_api_key: Some("sk-test-123".to_string()),
-        anthropic_api_key: None,
-        default_model: "gpt-4o".to_string(),
-        request_timeout: Duration::from_secs(30),
-    };
+    let config = make_config(Some("sk-test-123"), None);
     assert!(config.has_openai_key());
+}
+
+#[test]
+fn load_rein_toml() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("rein.toml"),
+        r#"
+[project]
+name = "my-project"
+version = "1.0.0"
+
+[runtime]
+default_model = "claude-3"
+timeout_secs = 60
+max_retries = 5
+
+[observability]
+trace_output = "traces/"
+"#,
+    )
+    .unwrap();
+
+    let config = Config::load_from_dir(tmp.path());
+    assert_eq!(config.default_model, "claude-3");
+    assert_eq!(config.request_timeout, Duration::from_secs(60));
+    assert_eq!(config.project.name, "my-project");
+    assert_eq!(config.project.version, "1.0.0");
+    assert_eq!(config.project.max_retries, 5);
+    assert_eq!(
+        config.project.trace_output,
+        Some("traces/".to_string())
+    );
+}
+
+#[test]
+fn load_missing_rein_toml_uses_defaults() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { env::remove_var("REIN_DEFAULT_MODEL") };
+    unsafe { env::remove_var("REIN_TIMEOUT_SECS") };
+    let config = Config::load_from_dir(tmp.path());
+    assert_eq!(config.default_model, "gpt-4o");
+    assert_eq!(config.project.max_retries, 3);
+}
+
+#[test]
+fn rein_toml_all_sections_deserialize() {
+    let toml_str = r#"
+[project]
+name = "test"
+version = "0.1.0"
+description = "A test project"
+
+[runtime]
+default_model = "gpt-4o"
+timeout_secs = 30
+max_retries = 3
+log_level = "debug"
+
+[registry]
+url = "https://registry.rein.dev"
+token_env = "REIN_TOKEN"
+
+[deploy]
+target = "aws"
+region = "us-east-1"
+
+[observability]
+trace_output = "traces/"
+metrics_endpoint = "http://localhost:9090"
+
+[dev]
+watch = true
+hot_reload = true
+"#;
+    let config: ReinToml = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.project.name, "test");
+    assert_eq!(config.registry.url, Some("https://registry.rein.dev".to_string()));
+    assert_eq!(config.deploy.target, Some("aws".to_string()));
+    assert!(config.dev.watch);
+    assert!(config.dev.hot_reload);
 }


### PR DESCRIPTION
Adds rein.toml support with [project], [runtime], [registry], [deploy], [observability], [dev] sections. Settings merge with env vars. Init command now generates rein.toml.\n\nCloses #135