### PR TITLE
feat(runtime): execute step blocks in workflow runner

### DIFF
--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -352,7 +352,48 @@ pub async fn run_parallel(
     Ok(build_result(stage_results, final_output))
 }
 
+/// Execute a single step definition, running its referenced agent with the
+/// step's goal as additional context.
+///
+/// # Errors
+/// Returns `WorkflowError` if the agent is not found or execution fails.
+pub async fn run_step(
+    step: &crate::ast::StepDef,
+    input: &str,
+    ctx: &WorkflowContext<'_>,
+) -> Result<StageResult, WorkflowError> {
+    // Build the effective input: original input + goal context
+    let effective_input = if let Some(ref goal) = step.goal {
+        format!("{input}\n\nGoal: {goal}")
+    } else {
+        input.to_string()
+    };
+
+    run_stage(&step.name, &step.agent, &effective_input, ctx).await
+}
+
+/// Execute all step blocks in a workflow sequentially, chaining outputs.
+///
+/// # Errors
+/// Returns `WorkflowError` if any step fails.
+pub async fn run_steps(
+    workflow: &WorkflowDef,
+    ctx: &WorkflowContext<'_>,
+) -> Result<Vec<StageResult>, WorkflowError> {
+    let mut results = Vec::new();
+    let mut current_input = format!("Trigger: {}", workflow.trigger);
+
+    for step in &workflow.steps {
+        let result = run_step(step, &current_input, ctx).await?;
+        current_input.clone_from(&result.output);
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
 /// Execute a workflow using its declared execution mode.
+/// If the workflow has step blocks, those are executed after stages.
 ///
 /// # Errors
 /// Returns `WorkflowError` if execution fails.
@@ -360,8 +401,21 @@ pub async fn run_workflow(
     workflow: &WorkflowDef,
     ctx: &WorkflowContext<'_>,
 ) -> Result<WorkflowResult, WorkflowError> {
-    match workflow.mode {
-        ExecutionMode::Sequential => run_sequential(workflow, ctx).await,
-        ExecutionMode::Parallel => run_parallel(workflow, ctx).await,
+    let mut result = match workflow.mode {
+        ExecutionMode::Sequential => run_sequential(workflow, ctx).await?,
+        ExecutionMode::Parallel => run_parallel(workflow, ctx).await?,
+    };
+
+    // Execute step blocks if present
+    if !workflow.steps.is_empty() {
+        let step_results = run_steps(workflow, ctx).await?;
+        for sr in step_results {
+            result.total_cost_cents += sr.cost_cents;
+            result.total_tokens += sr.tokens;
+            result.final_output.clone_from(&sr.output);
+            result.stage_results.push(sr);
+        }
     }
+
+    Ok(result)
 }

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -990,3 +990,55 @@ async fn circular_route_returns_error() {
         "expected CircularRoute, got: {err}"
     );
 }
+
+#[tokio::test]
+async fn step_execution_runs_agent_with_goal() {
+    use crate::ast::StepDef;
+    let file = parse_file(
+        r#"
+        agent writer { model: openai can [ docs.write ] }
+    "#,
+    );
+
+    let workflow = WorkflowDef {
+        name: "test_wf".to_string(),
+        trigger: "new_doc".to_string(),
+        stages: vec![],
+        steps: vec![StepDef {
+            name: "draft".to_string(),
+            agent: "writer".to_string(),
+            goal: Some("Write a first draft".to_string()),
+            input: None,
+            output_constraints: vec![],
+            when: None,
+            on_failure: None,
+            send_to: None,
+            fallback: None,
+            span: Span::new(0, 1),
+        }],
+        route_blocks: vec![],
+        parallel_blocks: vec![],
+        auto_resolve: None,
+        within_blocks: vec![],
+        mode: ExecutionMode::Sequential,
+        span: Span::new(0, 1),
+    };
+
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+    let ctx = WorkflowContext {
+        file: &file,
+        provider: &provider,
+        executor: &executor,
+        tool_defs: &[],
+        config: &RunConfig::default(),
+    };
+
+    provider.push_response(simple_response("Draft complete!"));
+
+    let result = run_workflow(&workflow, &ctx).await.unwrap();
+    assert_eq!(result.stage_results.len(), 1);
+    assert_eq!(result.stage_results[0].stage_name, "draft");
+    assert_eq!(result.stage_results[0].agent_name, "writer");
+    assert_eq!(result.final_output, "Draft complete!");
+}


### PR DESCRIPTION
Steps now execute their referenced agent with goal as context. Integrates with sequential/parallel modes.\n\nCloses #180