### PR TITLE
fix: QA fixes — context-sensitive keywords, wire parsers, split files (#227-#230)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -71,6 +71,9 @@ pub struct ReinFile {
     pub fleets: Vec<FleetDef>,
     pub channels: Vec<ChannelDef>,
     pub circuit_breakers: Vec<CircuitBreakerDef>,
+    pub evals: Vec<EvalDef>,
+    pub memories: Vec<MemoryDef>,
+    pub secrets: Vec<SecretsDef>,
 }
 
 #[cfg(test)]

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -102,7 +102,7 @@ fn agent_def_full_serializes() {
 
 #[test]
 fn rein_file_roundtrips_via_json() {
-    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![],
+    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],
@@ -193,7 +193,7 @@ fn workflow_def_serializes() {
         route_blocks: vec![],
         parallel_blocks: vec![],
         auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: dummy_span(),
     };
     let json = serde_json::to_value(&workflow).unwrap();
@@ -213,7 +213,7 @@ fn workflow_roundtrips_via_json() {
         route_blocks: vec![],
         parallel_blocks: vec![],
         auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Parallel,
+        mode: ExecutionMode::Parallel, schedule: None,
         span: dummy_span(),
     };
     let json = serde_json::to_string(&workflow).unwrap();
@@ -223,7 +223,7 @@ fn workflow_roundtrips_via_json() {
 
 #[test]
 fn rein_file_with_workflows_roundtrips() {
-    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![],
+    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],
@@ -237,7 +237,7 @@ fn rein_file_with_workflows_roundtrips() {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
-            mode: ExecutionMode::Sequential,
+            mode: ExecutionMode::Sequential, schedule: None,
             span: dummy_span(),
         }],
         types: vec![],
@@ -270,7 +270,7 @@ fn workflow_def_find_stage() {
         route_blocks: vec![],
         parallel_blocks: vec![],
         auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: dummy_span(),
     };
 

--- a/src/ast/workflow.rs
+++ b/src/ast/workflow.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use super::escalate::EscalateDef;
 use super::pipe::PipeExpr;
 use super::types::TypeExpr;
 use super::Span;
@@ -218,6 +219,14 @@ pub struct StepDef {
     pub send_to: Option<SendTarget>,
     /// Optional fallback step executed when the primary step fails.
     pub fallback: Option<Box<StepDef>>,
+    /// `for each: <collection>` iteration binding.
+    pub for_each: Option<String>,
+    /// Typed input binding: `input: <name>`.
+    pub typed_input: Option<String>,
+    /// Typed output bindings: `output: <name>: <TypeExpr>`.
+    pub typed_outputs: Vec<(String, TypeExpr)>,
+    /// Escalation to human: `escalate to human via channel("dest")`.
+    pub escalate: Option<EscalateDef>,
     pub span: Span,
 }
 
@@ -241,6 +250,8 @@ pub struct WorkflowDef {
     pub within_blocks: Vec<WithinBlock>,
     /// Default execution mode.
     pub mode: ExecutionMode,
+    /// Optional schedule for the workflow.
+    pub schedule: Option<crate::ast::ScheduleDef>,
     pub span: Span,
 }
 

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -47,10 +47,10 @@ fn collect_traces_from_dir(dir: &Path) -> Result<Vec<StructuredTrace>, std::io::
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().is_some_and(|e| e == "json") {
-            if let Ok(t) = load_trace(&path) {
-                traces.push(t);
-            }
+        if path.extension().is_some_and(|e| e == "json")
+            && let Ok(t) = load_trace(&path)
+        {
+            traces.push(t);
         }
     }
     Ok(traces)

--- a/src/commands/fmt.rs
+++ b/src/commands/fmt.rs
@@ -40,10 +40,8 @@ pub fn run_fmt(files: &[std::path::PathBuf], check: bool) -> i32 {
 
     if any_error {
         2
-    } else if check && any_changed {
-        1
     } else {
-        0
+        i32::from(check && any_changed)
     }
 }
 
@@ -119,7 +117,7 @@ pub fn format_source(source: &str) -> String {
         }
 
         // Indent and write line
-        let indent = "    ".repeat(depth as usize);
+        let indent = "    ".repeat(usize::try_from(depth).unwrap_or(0));
         let formatted_line = format_line(trimmed);
         output.push_str(&indent);
         output.push_str(&formatted_line);
@@ -134,7 +132,7 @@ pub fn format_source(source: &str) -> String {
         let closes = trimmed.chars().filter(|&c| c == '}' || c == ']').count();
         // We already decremented for leading close, so only count non-leading closes
         let effective_closes = if starts_with_close { closes - 1 } else { closes };
-        depth += opens as i32 - effective_closes as i32;
+        depth += i32::try_from(opens).unwrap_or(0) - i32::try_from(effective_closes).unwrap_or(0);
         if depth < 0 {
             depth = 0;
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-const EXAMPLE_REIN: &str = r#"// My first Rein agent
+const EXAMPLE_REIN: &str = r"// My first Rein agent
 
 agent assistant {
     model: openai
@@ -17,12 +17,12 @@ agent assistant {
 
     budget: $0.10 per request
 }
-"#;
+";
 
-const ENV_TEMPLATE: &str = r#"# Rein environment configuration
+const ENV_TEMPLATE: &str = r"# Rein environment configuration
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
-"#;
+";
 
 const REIN_TOML_TEMPLATE: &str = r#"[project]
 name = "{name}"
@@ -39,8 +39,7 @@ watch = false
 hot_reload = false
 "#;
 
-const GITIGNORE: &str = r#".env
-"#;
+const GITIGNORE: &str = ".env\n";
 
 const README_TEMPLATE: &str = r#"# My Rein Project
 
@@ -65,10 +64,9 @@ rein run agents/assistant.rein --message "Hello!"
 pub fn run_init(dir: &Path) -> i32 {
     let project_name = dir
         .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "my-rein-project".to_string());
+        .map_or_else(|| "my-rein-project".to_string(), |n| n.to_string_lossy().to_string());
 
-    if dir.exists() && dir.read_dir().map_or(false, |mut d| d.next().is_some()) {
+    if dir.exists() && dir.read_dir().is_ok_and(|mut d| d.next().is_some()) {
         eprintln!("Error: directory '{}' is not empty", dir.display());
         return 1;
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -126,10 +126,10 @@ impl Config {
 
         let mut toml_config = Self::load_toml(dir);
         let env_path = dir.join(format!("rein.env.{env_name}.toml"));
-        if let Ok(content) = std::fs::read_to_string(&env_path) {
-            if let Ok(overrides) = toml::from_str::<ReinToml>(&content) {
-                Self::merge_toml(&mut toml_config, &overrides);
-            }
+        if let Ok(content) = std::fs::read_to_string(&env_path)
+            && let Ok(overrides) = toml::from_str::<ReinToml>(&content)
+        {
+            Self::merge_toml(&mut toml_config, &overrides);
         }
 
         Self::from_toml(toml_config)

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -175,6 +175,82 @@ impl TokenKind {
         };
         Some(s)
     }
+
+    /// Map a word to its keyword `TokenKind`, or `None` if it's a plain identifier.
+    pub fn from_word(word: &str) -> Option<TokenKind> {
+        let kind = match word {
+            "agent" => Self::Agent, "archetype" => Self::Archetype,
+            "can" => Self::Can, "cannot" => Self::Cannot,
+            "model" => Self::Model, "budget" => Self::Budget,
+            "per" => Self::Per, "up" => Self::Up, "to" => Self::To,
+            "workflow" => Self::Workflow, "trigger" => Self::Trigger,
+            "stages" => Self::Stages, "provider" => Self::Provider,
+            "step" => Self::Step, "goal" => Self::Goal,
+            "tool" => Self::Tool, "endpoint" => Self::Endpoint,
+            "guardrails" => Self::Guardrails, "defaults" => Self::Defaults,
+            "one" => Self::One, "of" => Self::Of, "type" => Self::Type,
+            "import" => Self::Import, "from" => Self::From, "all" => Self::All,
+            "parallel" => Self::Parallel, "when" => Self::When,
+            "failure" => Self::Failure, "retry" => Self::Retry,
+            "then" => Self::Then, "exponential" => Self::Exponential,
+            "linear" => Self::Linear, "fixed" => Self::Fixed,
+            "escalate" => Self::Escalate, "fallback" => Self::Fallback,
+            "where" => Self::Where, "sort" => Self::Sort, "by" => Self::By,
+            "take" => Self::Take, "skip" => Self::Skip, "select" => Self::Select,
+            "unique" => Self::Unique, "asc" => Self::Asc, "desc" => Self::Desc,
+            "observe" => Self::Observe, "fleet" => Self::Fleet,
+            "channel" => Self::Channel, "trace" => Self::Trace,
+            "metrics" => Self::Metrics, "alert" => Self::Alert,
+            "export" => Self::Export, "agents" => Self::Agents,
+            "scaling" => Self::Scaling, "min" => Self::Min, "max" => Self::Max,
+            "retention" => Self::Retention, "send" => Self::Send,
+            "within" => Self::Within, "circuit_breaker" => Self::CircuitBreaker,
+            "auto" => Self::Auto, "resolve" => Self::Resolve,
+            "is" => Self::Is, "policy" => Self::Policy,
+            "tier" => Self::Tier, "promote" => Self::Promote,
+            "or" => Self::Or, "and" => Self::And,
+            "route" => Self::Route, "on" => Self::On,
+            "_" => Self::Underscore,
+            "eval" => Self::Eval, "dataset" => Self::Dataset,
+            "assert" => Self::Assert, "block" => Self::Block,
+            "deploy" => Self::Deploy, "memory" => Self::Memory,
+            "working" => Self::Working, "session" => Self::Session,
+            "knowledge" => Self::Knowledge, "schedule" => Self::Schedule,
+            "daily" => Self::Daily, "every" => Self::Every,
+            "hours" => Self::Hours, "for" => Self::For, "each" => Self::Each,
+            "input" => Self::Input, "output" => Self::Output,
+            "human" => Self::Human, "via" => Self::Via,
+            "secrets" => Self::Secrets, "vault" => Self::Vault,
+            _ => return None,
+        };
+        Some(kind)
+    }
+
+    /// If this keyword token can be used as an identifier in value positions,
+    /// return its string representation. Returns `None` for non-keyword tokens
+    /// and for structural keywords that start top-level blocks.
+    pub fn keyword_as_ident(&self) -> Option<&'static str> {
+        match self {
+            Self::Failure | Self::Retry | Self::Then | Self::Exponential
+            | Self::Linear | Self::Fixed | Self::Escalate | Self::One
+            | Self::Of | Self::On | Self::All | Self::From | Self::When
+            | Self::Route | Self::Parallel | Self::Auto | Self::Resolve
+            | Self::Is | Self::Policy | Self::Tier | Self::Fallback
+            | Self::Where | Self::Sort | Self::By | Self::Take | Self::Skip
+            | Self::Select | Self::Unique | Self::Asc | Self::Desc
+            | Self::Observe | Self::Fleet | Self::Channel | Self::Trace
+            | Self::Metrics | Self::Alert | Self::Export | Self::Agents
+            | Self::Scaling | Self::Min | Self::Max | Self::Retention
+            | Self::Send | Self::To | Self::Within | Self::CircuitBreaker
+            | Self::Promote | Self::Eval | Self::Dataset | Self::Assert
+            | Self::Block | Self::Deploy | Self::Memory | Self::Working
+            | Self::Session | Self::Knowledge | Self::Schedule | Self::Daily
+            | Self::Every | Self::Hours | Self::For | Self::Each
+            | Self::Input | Self::Output | Self::Human | Self::Via
+            | Self::Secrets | Self::Vault => self.keyword_str(),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for TokenKind {
@@ -217,407 +293,10 @@ pub struct LexError {
     pub span: Span,
 }
 
-/// Tokenize a `.rein` source string into a `Vec<Token>`.
-pub fn tokenize(source: &str) -> Result<Vec<Token>, LexError> {
-    let mut lexer = Lexer::new(source);
-    lexer.run()
-}
-
-/// Convert a dollar string (e.g. "0.03", "50") to integer cents without
-/// using f64, avoiding floating-point precision issues.
-fn parse_cents(s: &str) -> Result<u64, ()> {
-    let mut parts = s.splitn(2, '.');
-    let whole_str = parts.next().unwrap_or("0");
-    let frac_str = parts.next().unwrap_or("");
-
-    let whole: u64 = whole_str.parse().map_err(|_| ())?;
-
-    // Normalise fractional part to exactly 2 digits (truncate beyond cent).
-    let cents_str = match frac_str.len() {
-        0 => "00".to_string(),
-        1 => format!("{frac_str}0"),
-        _ => frac_str[..2].to_string(),
-    };
-    let cents: u64 = cents_str.parse().map_err(|_| ())?;
-
-    Ok(whole * 100 + cents)
-}
-
-struct Lexer<'a> {
-    src: &'a [u8],
-    pos: usize,
-}
-
-impl<'a> Lexer<'a> {
-    fn new(source: &'a str) -> Self {
-        Self {
-            src: source.as_bytes(),
-            pos: 0,
-        }
-    }
-
-    fn peek(&self) -> Option<u8> {
-        self.src.get(self.pos).copied()
-    }
-
-    fn peek_at(&self, offset: usize) -> Option<u8> {
-        self.src.get(self.pos + offset).copied()
-    }
-
-    fn advance(&mut self) -> Option<u8> {
-        let ch = self.src.get(self.pos).copied();
-        if ch.is_some() {
-            self.pos += 1;
-        }
-        ch
-    }
-
-    fn skip_whitespace(&mut self) {
-        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
-            self.advance();
-        }
-    }
-
-    fn read_ident(&mut self, start: usize) -> Token {
-        while matches!(
-            self.peek(),
-            Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
-        ) {
-            self.advance();
-        }
-        let end = self.pos;
-        let word = std::str::from_utf8(&self.src[start..end]).unwrap();
-        let kind = match word {
-            "agent" => TokenKind::Agent,
-            "archetype" => TokenKind::Archetype,
-            "can" => TokenKind::Can,
-            "cannot" => TokenKind::Cannot,
-            "model" => TokenKind::Model,
-            "budget" => TokenKind::Budget,
-            "per" => TokenKind::Per,
-            "up" => TokenKind::Up,
-            "to" => TokenKind::To,
-            "workflow" => TokenKind::Workflow,
-            "trigger" => TokenKind::Trigger,
-            "stages" => TokenKind::Stages,
-            "provider" => TokenKind::Provider,
-            // "key" is context-sensitive; lexed as Ident, matched in parser
-            "key" => TokenKind::Ident("key".to_string()),
-            "step" => TokenKind::Step,
-            "goal" => TokenKind::Goal,
-            "tool" => TokenKind::Tool,
-            "endpoint" => TokenKind::Endpoint,
-            "guardrails" => TokenKind::Guardrails,
-            "defaults" => TokenKind::Defaults,
-            "one" => TokenKind::One,
-            "of" => TokenKind::Of,
-            "type" => TokenKind::Type,
-            "import" => TokenKind::Import,
-            "from" => TokenKind::From,
-            "all" => TokenKind::All,
-            "parallel" => TokenKind::Parallel,
-            "when" => TokenKind::When,
-            "failure" => TokenKind::Failure,
-            "retry" => TokenKind::Retry,
-            "then" => TokenKind::Then,
-            "exponential" => TokenKind::Exponential,
-            "linear" => TokenKind::Linear,
-            "fixed" => TokenKind::Fixed,
-            "escalate" => TokenKind::Escalate,
-            "fallback" => TokenKind::Fallback,
-            "where" => TokenKind::Where,
-            "sort" => TokenKind::Sort,
-            "by" => TokenKind::By,
-            "take" => TokenKind::Take,
-            "skip" => TokenKind::Skip,
-            "select" => TokenKind::Select,
-            "unique" => TokenKind::Unique,
-            "asc" => TokenKind::Asc,
-            "desc" => TokenKind::Desc,
-            "observe" => TokenKind::Observe,
-            "fleet" => TokenKind::Fleet,
-            "channel" => TokenKind::Channel,
-            "trace" => TokenKind::Trace,
-            "metrics" => TokenKind::Metrics,
-            "alert" => TokenKind::Alert,
-            "export" => TokenKind::Export,
-            "agents" => TokenKind::Agents,
-            "scaling" => TokenKind::Scaling,
-            "min" => TokenKind::Min,
-            "max" => TokenKind::Max,
-            "retention" => TokenKind::Retention,
-            "send" => TokenKind::Send,
-            "within" => TokenKind::Within,
-            "circuit_breaker" => TokenKind::CircuitBreaker,
-            "auto" => TokenKind::Auto,
-            "resolve" => TokenKind::Resolve,
-            "is" => TokenKind::Is,
-            "policy" => TokenKind::Policy,
-            "tier" => TokenKind::Tier,
-            "promote" => TokenKind::Promote,
-            "or" => TokenKind::Or,
-            "and" => TokenKind::And,
-            "route" => TokenKind::Route,
-            "on" => TokenKind::On,
-            "_" => TokenKind::Underscore,
-            "eval" => TokenKind::Eval, "dataset" => TokenKind::Dataset,
-            "assert" => TokenKind::Assert, "block" => TokenKind::Block,
-            "deploy" => TokenKind::Deploy, "memory" => TokenKind::Memory,
-            "working" => TokenKind::Working, "session" => TokenKind::Session,
-            "knowledge" => TokenKind::Knowledge, "schedule" => TokenKind::Schedule,
-            "daily" => TokenKind::Daily, "every" => TokenKind::Every,
-            "hours" => TokenKind::Hours, "for" => TokenKind::For,
-            "each" => TokenKind::Each, "input" => TokenKind::Input,
-            "output" => TokenKind::Output, "human" => TokenKind::Human,
-            "via" => TokenKind::Via, "secrets" => TokenKind::Secrets,
-            "vault" => TokenKind::Vault,
-            _ => TokenKind::Ident(word.to_string()),
-        };
-        Token::new(kind, start, end)
-    }
-
-    fn read_number(&mut self, start: usize) -> Token {
-        while matches!(self.peek(), Some(b'0'..=b'9')) {
-            self.advance();
-        }
-        // Optional decimal part
-        if self.peek() == Some(b'.') && self.peek_at(1).is_some_and(|b| b.is_ascii_digit()) {
-            self.advance(); // consume '.'
-            while matches!(self.peek(), Some(b'0'..=b'9')) {
-                self.advance();
-            }
-        }
-        let end = self.pos;
-        let text = std::str::from_utf8(&self.src[start..end]).unwrap().to_string();
-        Token::new(TokenKind::Number(text), start, end)
-    }
-
-    fn read_currency(&mut self, symbol: char, start: usize) -> Result<Token, LexError> {
-        // Already consumed currency symbol at start; pos is now past it.
-        match self.peek() {
-            Some(b'0'..=b'9') => {}
-            Some(ch) => {
-                return Err(LexError {
-                    message: format!(
-                        "invalid currency amount: expected a number after '{symbol}', found '{}'",
-                        ch as char
-                    ),
-                    span: Span::new(start, self.pos + 1),
-                });
-            }
-            None => {
-                return Err(LexError {
-                    message: format!(
-                        "invalid currency amount: expected a number after '{symbol}', found end of input"
-                    ),
-                    span: Span::new(start, self.pos),
-                });
-            }
-        }
-
-        let num_start = self.pos;
-
-        while matches!(self.peek(), Some(b'0'..=b'9')) {
-            self.advance();
-        }
-
-        if self.peek() == Some(b'.') {
-            self.advance();
-
-            match self.peek() {
-                Some(b'0'..=b'9') => {}
-                Some(ch) => {
-                    return Err(LexError {
-                        message: format!(
-                            "invalid currency amount: expected digit after decimal point, found '{}'",
-                            ch as char
-                        ),
-                        span: Span::new(start, self.pos + 1),
-                    });
-                }
-                None => {
-                    return Err(LexError {
-                        message: "invalid currency amount: expected digit after decimal point, found end of input"
-                            .to_string(),
-                        span: Span::new(start, self.pos),
-                    });
-                }
-            }
-
-            while matches!(self.peek(), Some(b'0'..=b'9')) {
-                self.advance();
-            }
-
-            if self.peek() == Some(b'.') {
-                return Err(LexError {
-                    message: "invalid currency amount: too many decimal points".to_string(),
-                    span: Span::new(start, self.pos + 1),
-                });
-            }
-        }
-
-        let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).unwrap();
-        let cents = parse_cents(num_str).map_err(|()| LexError {
-            message: format!("invalid currency amount: '{symbol}{num_str}'"),
-            span: Span::new(start, self.pos),
-        })?;
-        Ok(Token::new(
-            TokenKind::Currency {
-                symbol,
-                amount: cents,
-            },
-            start,
-            self.pos,
-        ))
-    }
-
-    fn read_string(&mut self, start: usize) -> Result<Token, LexError> {
-        // Opening '"' already consumed; collect content until closing '"'.
-        let mut value = String::new();
-        loop {
-            match self.advance() {
-                None => {
-                    return Err(LexError {
-                        message: "unterminated string literal".to_string(),
-                        span: Span::new(start, self.pos),
-                    });
-                }
-                Some(b'"') => break,
-                Some(ch) => value.push(ch as char),
-            }
-        }
-        Ok(Token::new(TokenKind::StringLiteral(value), start, self.pos))
-    }
-
-    fn skip_line_comment(&mut self, start: usize) -> Token {
-        while !matches!(self.peek(), Some(b'\n') | None) {
-            self.advance();
-        }
-        Token::new(TokenKind::Comment, start, self.pos)
-    }
-
-    fn skip_block_comment(&mut self, start: usize) -> Result<Token, LexError> {
-        // already past '/*'
-        loop {
-            match self.peek() {
-                None => {
-                    return Err(LexError {
-                        message: "unterminated block comment".to_string(),
-                        span: Span::new(start, self.pos),
-                    });
-                }
-                Some(b'*') if self.peek_at(1) == Some(b'/') => {
-                    self.advance(); // '*'
-                    self.advance(); // '/'
-                    break;
-                }
-                _ => {
-                    self.advance();
-                }
-            }
-        }
-        Ok(Token::new(TokenKind::Comment, start, self.pos))
-    }
-
-    fn run(&mut self) -> Result<Vec<Token>, LexError> {
-        let mut tokens = Vec::new();
-        loop {
-            self.skip_whitespace();
-            let start = self.pos;
-            match self.advance() {
-                None => {
-                    tokens.push(Token::new(TokenKind::Eof, start, start));
-                    break;
-                }
-                Some(b'{') => tokens.push(Token::new(TokenKind::LBrace, start, self.pos)),
-                Some(b'}') => tokens.push(Token::new(TokenKind::RBrace, start, self.pos)),
-                Some(b'[') => tokens.push(Token::new(TokenKind::LBracket, start, self.pos)),
-                Some(b']') => tokens.push(Token::new(TokenKind::RBracket, start, self.pos)),
-                Some(b'(') => tokens.push(Token::new(TokenKind::LParen, start, self.pos)),
-                Some(b')') => tokens.push(Token::new(TokenKind::RParen, start, self.pos)),
-                Some(b':') => tokens.push(Token::new(TokenKind::Colon, start, self.pos)),
-                Some(b'.') => {
-                    if self.peek() == Some(b'.') {
-                        self.advance();
-                        tokens.push(Token::new(TokenKind::DotDot, start, self.pos));
-                    } else {
-                        tokens.push(Token::new(TokenKind::Dot, start, self.pos));
-                    }
-                }
-                Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
-                Some(b'"') => tokens.push(self.read_string(start)?),
-                Some(b'$') => tokens.push(self.read_currency('$', start)?),
-                Some(b'#') => {
-                    tokens.push(self.skip_line_comment(start));
-                }
-                Some(b'/') if self.peek() == Some(b'/') => {
-                    self.advance(); // second '/'
-                    tokens.push(self.skip_line_comment(start));
-                }
-                Some(b'/') if self.peek() == Some(b'*') => {
-                    self.advance(); // '*'
-                    tokens.push(self.skip_block_comment(start)?);
-                }
-                Some(b'/') => tokens.push(Token::new(TokenKind::Slash, start, self.pos)),
-                Some(b'@') => tokens.push(Token::new(TokenKind::At, start, self.pos)),
-                Some(b'-') if self.peek() == Some(b'>') => {
-                    self.advance(); // consume '>'
-                    tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
-                }
-                Some(b'<') => {
-                    if self.peek() == Some(b'=') {
-                        self.advance();
-                        tokens.push(Token::new(TokenKind::LtEq, start, self.pos));
-                    } else {
-                        tokens.push(Token::new(TokenKind::Lt, start, self.pos));
-                    }
-                }
-                Some(b'>') => {
-                    if self.peek() == Some(b'=') {
-                        self.advance();
-                        tokens.push(Token::new(TokenKind::GtEq, start, self.pos));
-                    } else {
-                        tokens.push(Token::new(TokenKind::Gt, start, self.pos));
-                    }
-                }
-                Some(b'%') => tokens.push(Token::new(TokenKind::Percent, start, self.pos)),
-                Some(b'|') => tokens.push(Token::new(TokenKind::Pipe, start, self.pos)),
-                Some(ch) if ch.is_ascii_digit() => {
-                    tokens.push(self.read_number(start));
-                }
-                Some(ch) if ch.is_ascii_alphabetic() || ch == b'_' => {
-                    tokens.push(self.read_ident(start));
-                }
-                // Multi-byte currency symbols: £ (C2 A3), ¥ (C2 A5), € (E2 82 AC)
-                Some(0xC2) if matches!(self.peek(), Some(0xA3 | 0xA5)) => {
-                    let sym = if self.src[self.pos] == 0xA3 {
-                        '£'
-                    } else {
-                        '¥'
-                    };
-                    self.advance(); // consume second byte
-                    tokens.push(self.read_currency(sym, start)?);
-                }
-                Some(0xE2)
-                    if self.pos + 1 < self.src.len()
-                        && self.src[self.pos] == 0x82
-                        && self.src[self.pos + 1] == 0xAC =>
-                {
-                    self.advance(); // consume 0x82
-                    self.advance(); // consume 0xAC
-                    tokens.push(self.read_currency('€', start)?);
-                }
-                Some(ch) => {
-                    return Err(LexError {
-                        message: format!("unexpected character: '{}'", ch as char),
-                        span: Span::new(start, self.pos),
-                    });
-                }
-            }
-        }
-        Ok(tokens)
-    }
-}
+mod scanner;
+pub use scanner::tokenize;
+#[cfg(test)]
+pub(crate) use scanner::parse_cents;
 
 #[cfg(test)]
 mod tests;

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -1,0 +1,325 @@
+use crate::ast::Span;
+
+use super::{LexError, Token, TokenKind};
+
+/// Tokenize a `.rein` source string into a `Vec<Token>`.
+pub fn tokenize(source: &str) -> Result<Vec<Token>, LexError> {
+    let mut lexer = Lexer::new(source);
+    lexer.run()
+}
+
+/// Convert a dollar string (e.g. "0.03", "50") to integer cents without
+/// using f64, avoiding floating-point precision issues.
+pub(crate) fn parse_cents(s: &str) -> Result<u64, ()> {
+    let mut parts = s.splitn(2, '.');
+    let whole_str = parts.next().unwrap_or("0");
+    let frac_str = parts.next().unwrap_or("");
+
+    let whole: u64 = whole_str.parse().map_err(|_| ())?;
+
+    // Normalise fractional part to exactly 2 digits (truncate beyond cent).
+    let cents_str = match frac_str.len() {
+        0 => "00".to_string(),
+        1 => format!("{frac_str}0"),
+        _ => frac_str[..2].to_string(),
+    };
+    let cents: u64 = cents_str.parse().map_err(|_| ())?;
+
+    Ok(whole * 100 + cents)
+}
+
+struct Lexer<'a> {
+    src: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            src: source.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.src.get(self.pos).copied()
+    }
+
+    fn peek_at(&self, offset: usize) -> Option<u8> {
+        self.src.get(self.pos + offset).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let ch = self.src.get(self.pos).copied();
+        if ch.is_some() {
+            self.pos += 1;
+        }
+        ch
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            self.advance();
+        }
+    }
+
+    fn read_ident(&mut self, start: usize) -> Token {
+        while matches!(
+            self.peek(),
+            Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+        ) {
+            self.advance();
+        }
+        let end = self.pos;
+        let word = std::str::from_utf8(&self.src[start..end]).unwrap();
+        // "key" is context-sensitive; lexed as Ident, matched in parser
+        let kind = if word == "key" {
+            TokenKind::Ident("key".to_string())
+        } else {
+            TokenKind::from_word(word).unwrap_or_else(|| TokenKind::Ident(word.to_string()))
+        };
+        Token::new(kind, start, end)
+    }
+
+    fn read_number(&mut self, start: usize) -> Token {
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.advance();
+        }
+        // Optional decimal part
+        if self.peek() == Some(b'.') && self.peek_at(1).is_some_and(|b| b.is_ascii_digit()) {
+            self.advance(); // consume '.'
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.advance();
+            }
+        }
+        let end = self.pos;
+        let text = std::str::from_utf8(&self.src[start..end]).unwrap().to_string();
+        Token::new(TokenKind::Number(text), start, end)
+    }
+
+    fn read_currency(&mut self, symbol: char, start: usize) -> Result<Token, LexError> {
+        // Already consumed currency symbol at start; pos is now past it.
+        match self.peek() {
+            Some(b'0'..=b'9') => {}
+            Some(ch) => {
+                return Err(LexError {
+                    message: format!(
+                        "invalid currency amount: expected a number after '{symbol}', found '{}'",
+                        ch as char
+                    ),
+                    span: Span::new(start, self.pos + 1),
+                });
+            }
+            None => {
+                return Err(LexError {
+                    message: format!(
+                        "invalid currency amount: expected a number after '{symbol}', found end of input"
+                    ),
+                    span: Span::new(start, self.pos),
+                });
+            }
+        }
+
+        let num_start = self.pos;
+
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.advance();
+        }
+
+        if self.peek() == Some(b'.') {
+            self.advance();
+
+            match self.peek() {
+                Some(b'0'..=b'9') => {}
+                Some(ch) => {
+                    return Err(LexError {
+                        message: format!(
+                            "invalid currency amount: expected digit after decimal point, found '{}'",
+                            ch as char
+                        ),
+                        span: Span::new(start, self.pos + 1),
+                    });
+                }
+                None => {
+                    return Err(LexError {
+                        message: "invalid currency amount: expected digit after decimal point, found end of input"
+                            .to_string(),
+                        span: Span::new(start, self.pos),
+                    });
+                }
+            }
+
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.advance();
+            }
+
+            if self.peek() == Some(b'.') {
+                return Err(LexError {
+                    message: "invalid currency amount: too many decimal points".to_string(),
+                    span: Span::new(start, self.pos + 1),
+                });
+            }
+        }
+
+        let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).unwrap();
+        let cents = parse_cents(num_str).map_err(|()| LexError {
+            message: format!("invalid currency amount: '{symbol}{num_str}'"),
+            span: Span::new(start, self.pos),
+        })?;
+        Ok(Token::new(
+            TokenKind::Currency {
+                symbol,
+                amount: cents,
+            },
+            start,
+            self.pos,
+        ))
+    }
+
+    fn read_string(&mut self, start: usize) -> Result<Token, LexError> {
+        // Opening '"' already consumed; collect content until closing '"'.
+        let mut value = String::new();
+        loop {
+            match self.advance() {
+                None => {
+                    return Err(LexError {
+                        message: "unterminated string literal".to_string(),
+                        span: Span::new(start, self.pos),
+                    });
+                }
+                Some(b'"') => break,
+                Some(ch) => value.push(ch as char),
+            }
+        }
+        Ok(Token::new(TokenKind::StringLiteral(value), start, self.pos))
+    }
+
+    fn skip_line_comment(&mut self, start: usize) -> Token {
+        while !matches!(self.peek(), Some(b'\n') | None) {
+            self.advance();
+        }
+        Token::new(TokenKind::Comment, start, self.pos)
+    }
+
+    fn skip_block_comment(&mut self, start: usize) -> Result<Token, LexError> {
+        // already past '/*'
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(LexError {
+                        message: "unterminated block comment".to_string(),
+                        span: Span::new(start, self.pos),
+                    });
+                }
+                Some(b'*') if self.peek_at(1) == Some(b'/') => {
+                    self.advance(); // '*'
+                    self.advance(); // '/'
+                    break;
+                }
+                _ => {
+                    self.advance();
+                }
+            }
+        }
+        Ok(Token::new(TokenKind::Comment, start, self.pos))
+    }
+
+    fn run(&mut self) -> Result<Vec<Token>, LexError> {
+        let mut tokens = Vec::new();
+        loop {
+            self.skip_whitespace();
+            let start = self.pos;
+            match self.advance() {
+                None => {
+                    tokens.push(Token::new(TokenKind::Eof, start, start));
+                    break;
+                }
+                Some(b'{') => tokens.push(Token::new(TokenKind::LBrace, start, self.pos)),
+                Some(b'}') => tokens.push(Token::new(TokenKind::RBrace, start, self.pos)),
+                Some(b'[') => tokens.push(Token::new(TokenKind::LBracket, start, self.pos)),
+                Some(b']') => tokens.push(Token::new(TokenKind::RBracket, start, self.pos)),
+                Some(b'(') => tokens.push(Token::new(TokenKind::LParen, start, self.pos)),
+                Some(b')') => tokens.push(Token::new(TokenKind::RParen, start, self.pos)),
+                Some(b':') => tokens.push(Token::new(TokenKind::Colon, start, self.pos)),
+                Some(b'.') => {
+                    if self.peek() == Some(b'.') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::DotDot, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Dot, start, self.pos));
+                    }
+                }
+                Some(b',') => tokens.push(Token::new(TokenKind::Comma, start, self.pos)),
+                Some(b'"') => tokens.push(self.read_string(start)?),
+                Some(b'$') => tokens.push(self.read_currency('$', start)?),
+                Some(b'#') => {
+                    tokens.push(self.skip_line_comment(start));
+                }
+                Some(b'/') if self.peek() == Some(b'/') => {
+                    self.advance(); // second '/'
+                    tokens.push(self.skip_line_comment(start));
+                }
+                Some(b'/') if self.peek() == Some(b'*') => {
+                    self.advance(); // '*'
+                    tokens.push(self.skip_block_comment(start)?);
+                }
+                Some(b'/') => tokens.push(Token::new(TokenKind::Slash, start, self.pos)),
+                Some(b'@') => tokens.push(Token::new(TokenKind::At, start, self.pos)),
+                Some(b'-') if self.peek() == Some(b'>') => {
+                    self.advance(); // consume '>'
+                    tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
+                }
+                Some(b'<') => {
+                    if self.peek() == Some(b'=') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::LtEq, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Lt, start, self.pos));
+                    }
+                }
+                Some(b'>') => {
+                    if self.peek() == Some(b'=') {
+                        self.advance();
+                        tokens.push(Token::new(TokenKind::GtEq, start, self.pos));
+                    } else {
+                        tokens.push(Token::new(TokenKind::Gt, start, self.pos));
+                    }
+                }
+                Some(b'%') => tokens.push(Token::new(TokenKind::Percent, start, self.pos)),
+                Some(b'|') => tokens.push(Token::new(TokenKind::Pipe, start, self.pos)),
+                Some(ch) if ch.is_ascii_digit() => {
+                    tokens.push(self.read_number(start));
+                }
+                Some(ch) if ch.is_ascii_alphabetic() || ch == b'_' => {
+                    tokens.push(self.read_ident(start));
+                }
+                // Multi-byte currency symbols: £ (C2 A3), ¥ (C2 A5), € (E2 82 AC)
+                Some(0xC2) if matches!(self.peek(), Some(0xA3 | 0xA5)) => {
+                    let sym = if self.src[self.pos] == 0xA3 {
+                        '£'
+                    } else {
+                        '¥'
+                    };
+                    self.advance(); // consume second byte
+                    tokens.push(self.read_currency(sym, start)?);
+                }
+                Some(0xE2)
+                    if self.pos + 1 < self.src.len()
+                        && self.src[self.pos] == 0x82
+                        && self.src[self.pos + 1] == 0xAC =>
+                {
+                    self.advance(); // consume 0x82
+                    self.advance(); // consume 0xAC
+                    tokens.push(self.read_currency('€', start)?);
+                }
+                Some(ch) => {
+                    return Err(LexError {
+                        message: format!("unexpected character: '{}'", ch as char),
+                        span: Span::new(start, self.pos),
+                    });
+                }
+            }
+        }
+        Ok(tokens)
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,6 +15,7 @@ mod pipe_parser;
 mod policy_parser;
 mod schedule_parser;
 mod secrets_parser;
+mod step_extensions;
 mod step_parser;
 mod type_parser;
 mod within_parser;
@@ -198,6 +199,12 @@ impl Parser {
                 self.advance();
                 Ok(ValueExpr::Literal(s))
             }
+            // Keywords that can appear as values in certain contexts
+            kind if kind.keyword_as_ident().is_some() => {
+                let name = kind.keyword_as_ident().unwrap().to_string();
+                self.advance();
+                Ok(ValueExpr::Literal(name))
+            }
             _ => Err(ParseError::new(
                 format!(
                     "expected value (identifier, string, or env()), got {}",
@@ -209,72 +216,24 @@ impl Parser {
     }
 
     /// Consume an `Ident` token and return its string value + span.
+    /// Keywords that can appear as identifiers in value positions are accepted.
     fn expect_ident(&mut self) -> Result<(String, Span), ParseError> {
         self.skip_comments();
         let tok = self.current().clone();
-        match &tok.kind {
-            TokenKind::Ident(name) => {
-                let name = name.clone();
-                self.advance();
-                Ok((name, tok.span))
-            }
-            // Contextual keywords that can appear as identifiers
-            TokenKind::Failure
-            | TokenKind::Retry
-            | TokenKind::Then
-            | TokenKind::Exponential
-            | TokenKind::Linear
-            | TokenKind::Fixed
-            | TokenKind::Escalate
-            | TokenKind::One
-            | TokenKind::Of
-            | TokenKind::On
-            | TokenKind::All
-            | TokenKind::From
-            | TokenKind::When
-            | TokenKind::Route
-            | TokenKind::Parallel
-            | TokenKind::Auto
-            | TokenKind::Resolve
-            | TokenKind::Is
-            | TokenKind::Policy
-            | TokenKind::Tier
-            | TokenKind::Fallback
-            | TokenKind::Where
-            | TokenKind::Sort
-            | TokenKind::By
-            | TokenKind::Take
-            | TokenKind::Skip
-            | TokenKind::Select
-            | TokenKind::Unique
-            | TokenKind::Asc
-            | TokenKind::Desc
-            | TokenKind::Observe
-            | TokenKind::Fleet
-            | TokenKind::Channel
-            | TokenKind::Trace
-            | TokenKind::Metrics
-            | TokenKind::Alert
-            | TokenKind::Export
-            | TokenKind::Agents
-            | TokenKind::Scaling
-            | TokenKind::Min
-            | TokenKind::Max
-            | TokenKind::Retention
-            | TokenKind::Send
-            | TokenKind::To
-            | TokenKind::Within
-            | TokenKind::CircuitBreaker
-            | TokenKind::Promote => {
-                let name = tok.kind.to_string();
-                self.advance();
-                Ok((name, tok.span))
-            }
-            _ => Err(ParseError::new(
-                format!("expected identifier, got {}", tok.kind),
-                tok.span,
-            )),
+        if let TokenKind::Ident(name) = &tok.kind {
+            let name = name.clone();
+            self.advance();
+            return Ok((name, tok.span));
         }
+        if let Some(name) = tok.kind.keyword_as_ident() {
+            let name = name.to_string();
+            self.advance();
+            return Ok((name, tok.span));
+        }
+        Err(ParseError::new(
+            format!("expected identifier, got {}", tok.kind),
+            tok.span,
+        ))
     }
 
     /// Expect an identifier or keyword token, returning the text.
@@ -353,6 +312,9 @@ impl Parser {
         let mut fleets = Vec::new();
         let mut channels = Vec::new();
         let mut circuit_breakers = Vec::new();
+        let mut evals = Vec::new();
+        let mut memories = Vec::new();
+        let mut secrets = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
                 TokenKind::Import => imports.push(self.parse_import()?),
@@ -378,6 +340,15 @@ impl Parser {
                 TokenKind::CircuitBreaker => {
                     circuit_breakers.push(self.parse_circuit_breaker()?);
                 }
+                TokenKind::Eval => evals.push(self.parse_eval()?),
+                TokenKind::Memory => memories.push(self.parse_memory()?),
+                TokenKind::Schedule => {
+                    return Err(ParseError::new(
+                        "'schedule' must appear inside a workflow block",
+                        self.current_span(),
+                    ));
+                }
+                TokenKind::Secrets => secrets.push(self.parse_secrets()?),
                 other => {
                     return Err(ParseError::new(
                         format!(
@@ -403,6 +374,9 @@ impl Parser {
             fleets,
             channels,
             circuit_breakers,
+            evals,
+            memories,
+            secrets,
         })
     }
 }

--- a/src/parser/schedule_parser.rs
+++ b/src/parser/schedule_parser.rs
@@ -23,7 +23,7 @@ impl Parser {
                             self.current_span(),
                         ));
                     }
-                };
+                }
                 // Parse time: could be "2am", "14:30", etc. — grab as string or ident
                 let time = match self.peek().clone() {
                     TokenKind::StringLiteral(s) | TokenKind::Ident(s) => {

--- a/src/parser/step_extensions.rs
+++ b/src/parser/step_extensions.rs
@@ -1,0 +1,88 @@
+use crate::ast::{EscalateDef, Span, TypeExpr};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `for each: <collection>`.
+    pub(super) fn parse_step_for_each(
+        &mut self,
+        name: &str,
+        for_each: &mut Option<String>,
+    ) -> Result<(), ParseError> {
+        if for_each.is_some() {
+            return Err(ParseError::new(
+                format!("duplicate 'for each' in step '{name}'"),
+                self.current_span(),
+            ));
+        }
+        self.expect(&TokenKind::For)?;
+        self.expect(&TokenKind::Each)?;
+        self.expect(&TokenKind::Colon)?;
+        let (collection, _) = self.expect_ident()?;
+        *for_each = Some(collection);
+        Ok(())
+    }
+
+    /// Parse `escalate to human via channel("destination")`.
+    pub(super) fn parse_step_escalate(
+        &mut self,
+        name: &str,
+        escalate: &mut Option<EscalateDef>,
+    ) -> Result<(), ParseError> {
+        if escalate.is_some() {
+            return Err(ParseError::new(
+                format!("duplicate 'escalate' in step '{name}'"),
+                self.current_span(),
+            ));
+        }
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Escalate)?;
+        self.expect(&TokenKind::To)?;
+        let (target, _) = self.expect_ident()?;
+        self.expect(&TokenKind::Via)?;
+        let (channel, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LParen)?;
+        let destination = self.expect_string()?;
+        let end_span = self.expect(&TokenKind::RParen)?;
+        *escalate = Some(EscalateDef {
+            target,
+            channel,
+            destination,
+            span: Span::new(start, end_span.end),
+        });
+        Ok(())
+    }
+
+    /// Parse `output: <name>: <Type>`.
+    pub(super) fn parse_step_typed_output(
+        &mut self,
+        _name: &str,
+        typed_outputs: &mut Vec<(String, TypeExpr)>,
+    ) -> Result<(), ParseError> {
+        self.expect(&TokenKind::Output)?;
+        self.expect(&TokenKind::Colon)?;
+        let (field_name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::Colon)?;
+        let type_expr = self.parse_type_expr_inline()?;
+        typed_outputs.push((field_name, type_expr));
+        Ok(())
+    }
+
+    /// Parse an inline type expression like `Product[]` or `String`.
+    pub(super) fn parse_type_expr_inline(&mut self) -> Result<TypeExpr, ParseError> {
+        let (type_name, _) = self.expect_ident()?;
+        // Check for array suffix `[]`
+        let array = if *self.peek() == TokenKind::LBracket {
+            self.advance();
+            self.expect(&TokenKind::RBracket)?;
+            true
+        } else {
+            false
+        };
+        Ok(TypeExpr::Named {
+            name: type_name,
+            array,
+        })
+    }
+}

--- a/src/parser/step_parser.rs
+++ b/src/parser/step_parser.rs
@@ -1,4 +1,4 @@
-use crate::ast::{PipeExpr, RetryPolicy, SendTarget, Span, StepDef, TypeExpr, ValueExpr, WhenExpr};
+use crate::ast::{EscalateDef, PipeExpr, RetryPolicy, SendTarget, Span, StepDef, TypeExpr, ValueExpr, WhenExpr};
 use crate::lexer::TokenKind;
 
 use super::{ParseError, Parser};
@@ -14,6 +14,10 @@ struct StepFields {
     when: Option<WhenExpr>,
     on_failure: Option<RetryPolicy>,
     fallback: Option<Box<StepDef>>,
+    for_each: Option<String>,
+    typed_input: Option<String>,
+    typed_outputs: Vec<(String, TypeExpr)>,
+    escalate: Option<EscalateDef>,
     seen_agent: bool,
     seen_goal: bool,
 }
@@ -67,6 +71,10 @@ impl Parser {
                         when: f.when,
                         on_failure: f.on_failure,
                         fallback: f.fallback,
+                        for_each: f.for_each,
+                        typed_input: f.typed_input,
+                        typed_outputs: f.typed_outputs,
+                        escalate: f.escalate,
                         span: Span::new(start, end),
                     });
                 }
@@ -87,6 +95,55 @@ impl Parser {
                 }
                 TokenKind::Fallback => {
                     self.parse_step_fallback(&name, &mut f.fallback)?;
+                }
+                TokenKind::For => {
+                    self.parse_step_for_each(&name, &mut f.for_each)?;
+                }
+                TokenKind::Escalate => {
+                    self.parse_step_escalate(&name, &mut f.escalate)?;
+                }
+                TokenKind::Input => {
+                    // `input:` can be a typed input binding or a pipe expression.
+                    // We peek ahead: if it's `input: <ident>` with no pipe, it's typed_input.
+                    // Otherwise, fall through to pipe parsing.
+                    self.advance(); // consume `input`
+                    self.expect(&TokenKind::Colon)?;
+                    // Check if next is a simple ident without pipe
+                    if matches!(self.peek(), TokenKind::Ident(_)) || self.peek().keyword_as_ident().is_some() {
+                        // Check if followed by pipe
+                        if self.peek_at(1) == Some(&TokenKind::Pipe) {
+                            // It's a pipe expression — parse as input
+                            if f.input.is_some() {
+                                return Err(ParseError::new(
+                                    format!("duplicate field 'input' in step '{name}'"),
+                                    self.current_span(),
+                                ));
+                            }
+                            f.input = Some(self.parse_pipe_expr()?);
+                        } else {
+                            // Simple typed input
+                            if f.typed_input.is_some() {
+                                return Err(ParseError::new(
+                                    format!("duplicate 'input' in step '{name}'"),
+                                    self.current_span(),
+                                ));
+                            }
+                            let (input_name, _) = self.expect_ident()?;
+                            f.typed_input = Some(input_name);
+                        }
+                    } else {
+                        // Likely a pipe expression starting with something else
+                        if f.input.is_some() {
+                            return Err(ParseError::new(
+                                format!("duplicate field 'input' in step '{name}'"),
+                                self.current_span(),
+                            ));
+                        }
+                        f.input = Some(self.parse_pipe_expr()?);
+                    }
+                }
+                TokenKind::Output => {
+                    self.parse_step_typed_output(&name, &mut f.typed_outputs)?;
                 }
                 _ => {
                     self.parse_step_field_or_error(&name, &mut f)?;
@@ -289,6 +346,10 @@ impl Parser {
             when: None,
             on_failure: None,
             fallback: None,
+            for_each: None,
+            typed_input: None,
+            typed_outputs: Vec::new(),
+            escalate: None,
             span: Span::new(start, end),
         })
     }

--- a/src/parser/workflow_parser.rs
+++ b/src/parser/workflow_parser.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     AutoResolveBlock, AutoResolveCondition, CompareOp, ExecutionMode, ParallelBlock, RouteArm,
-    RouteBlock, RoutePattern, RouteRule, Span, Stage, StepDef, TypeExpr, WhenComparison,
-    WithinBlock, WorkflowDef,
+    RouteBlock, RoutePattern, RouteRule, ScheduleDef, Span, Stage, StepDef, TypeExpr,
+    WhenComparison, WithinBlock, WorkflowDef,
 };
 use crate::lexer::TokenKind;
 
@@ -16,6 +16,7 @@ struct WorkflowBody {
     parallel_blocks: Vec<ParallelBlock>,
     auto_resolve: Option<AutoResolveBlock>,
     within_blocks: Vec<WithinBlock>,
+    schedule: Option<ScheduleDef>,
 }
 
 impl Parser {
@@ -64,6 +65,7 @@ impl Parser {
             auto_resolve: body.auto_resolve,
             within_blocks: body.within_blocks,
             mode: ExecutionMode::Sequential,
+            schedule: body.schedule,
             span: Span::new(start, end),
         })
     }
@@ -103,6 +105,15 @@ impl Parser {
                 TokenKind::Within => body.within_blocks.push(self.parse_within_block()?),
                 TokenKind::Route => body.route_blocks.push(self.parse_route_block()?),
                 TokenKind::Parallel => body.parallel_blocks.push(self.parse_parallel_block()?),
+                TokenKind::Schedule => {
+                    if body.schedule.is_some() {
+                        return Err(ParseError::new(
+                            format!("duplicate 'schedule' in workflow '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    body.schedule = Some(self.parse_schedule()?);
+                }
                 TokenKind::Auto => {
                     if body.auto_resolve.is_some() {
                         return Err(ParseError::new(

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 
 use super::*;
 use crate::ast::ValueExpr;
-use crate::ast::{AgentDef, Capability, Constraint, Span};
+use crate::ast::{AgentDef, Capability, Span};
 use crate::runtime::executor::MockExecutor;
 use crate::runtime::provider::{ChatResponse, MockProvider, ToolCallRequest, ToolDef, Usage};
 

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -7,8 +7,10 @@ use super::provider::{Provider, ToolDef};
 
 mod condition;
 pub mod persistence;
+mod resumable;
 
 use condition::condition_matches;
+pub use resumable::run_sequential_resumable;
 
 #[cfg(test)]
 mod tests;
@@ -83,7 +85,7 @@ impl std::fmt::Display for WorkflowError {
 impl std::error::Error for WorkflowError {}
 
 /// Run a single stage and return its result.
-async fn run_stage(
+pub(super) async fn run_stage(
     stage_name: &str,
     agent_name: &str,
     input: &str,
@@ -123,7 +125,7 @@ async fn run_stage(
 }
 
 /// Collect stage results into a `WorkflowResult`.
-fn build_result(stage_results: Vec<StageResult>, final_output: String) -> WorkflowResult {
+pub(super) fn build_result(stage_results: Vec<StageResult>, final_output: String) -> WorkflowResult {
     let total_cost = stage_results.iter().map(|r| r.cost_cents).sum();
     let total_tokens = stage_results.iter().map(|r| r.tokens).sum();
     WorkflowResult {
@@ -138,7 +140,7 @@ fn build_result(stage_results: Vec<StageResult>, final_output: String) -> Workfl
 ///
 /// This is the single source of truth for routing logic, used by both
 /// `run_sequential` and `run_sequential_resumable`.
-fn resolve_next_stage<'a>(
+pub(super) fn resolve_next_stage<'a>(
     workflow: &'a WorkflowDef,
     current: &Stage,
     output: &str,
@@ -212,120 +214,6 @@ pub async fn run_sequential(
 /// state if none exists (or the checkpoint is for a different workflow).
 ///
 /// Returns `(stage_results, current_input, skip_stages)`.
-fn build_resume_context(
-    checkpoint: Option<&persistence::WorkflowState>,
-    workflow: &WorkflowDef,
-) -> (Vec<StageResult>, String, std::collections::HashSet<String>) {
-    let default_input = format!("Trigger: {}", workflow.trigger);
-    if let Some(state) = checkpoint.filter(|s| s.workflow_name == workflow.name) {
-        let prior_results = state
-            .completed_stages
-            .iter()
-            .map(|cs| StageResult {
-                stage_name: cs.stage_name.clone(),
-                agent_name: cs.agent_name.clone(),
-                output: cs.output.clone(),
-                cost_cents: cs.cost_cents,
-                tokens: cs.tokens,
-            })
-            .collect();
-        let skip = state
-            .completed_stages
-            .iter()
-            .map(|cs| cs.stage_name.clone())
-            .collect();
-        return (prior_results, state.next_input.clone(), skip);
-    }
-    (Vec::new(), default_input, std::collections::HashSet::new())
-}
-
-/// Determine the stage to (re)start from given a checkpoint.
-fn find_resume_start<'a>(
-    workflow: &'a WorkflowDef,
-    checkpoint: Option<&persistence::WorkflowState>,
-    skip_stages: &std::collections::HashSet<String>,
-) -> Result<Option<&'a Stage>, WorkflowError> {
-    if skip_stages.is_empty() {
-        return Ok(workflow.stages.first());
-    }
-    let Some(last_cs) = checkpoint.and_then(|s| s.completed_stages.last()) else {
-        return Ok(workflow.stages.first());
-    };
-    let Some(last_stage) = workflow.find_stage(&last_cs.stage_name) else {
-        return Ok(workflow.stages.first());
-    };
-    resolve_next_stage(workflow, last_stage, &last_cs.output)
-}
-
-/// Execute a workflow sequentially with checkpoint persistence.
-///
-/// After each stage completes, state is saved to `state_path` as JSON.
-/// If a previous state file exists for this workflow, execution resumes
-/// from the last completed stage. On successful completion the state file
-/// is removed.
-///
-/// # Errors
-/// Returns `WorkflowError` if an agent is missing, a stage fails, a route
-/// references a nonexistent stage, circular routing is detected, or state
-/// persistence fails.
-pub async fn run_sequential_resumable(
-    workflow: &WorkflowDef,
-    ctx: &WorkflowContext<'_>,
-    state_path: &std::path::Path,
-) -> Result<WorkflowResult, WorkflowError> {
-    use persistence::{CompletedStage, WorkflowState, clear_state, load_state, save_state};
-
-    let checkpoint =
-        load_state(state_path).map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
-
-    let (mut stage_results, mut current_input, skip_stages) =
-        build_resume_context(checkpoint.as_ref(), workflow);
-    let mut visited: std::collections::HashSet<&str> =
-        skip_stages.iter().map(String::as_str).collect();
-    let mut current_stage = find_resume_start(workflow, checkpoint.as_ref(), &skip_stages)?;
-
-    while let Some(stage) = current_stage {
-        if !visited.insert(&stage.name) {
-            return Err(WorkflowError::CircularRoute(stage.name.clone()));
-        }
-
-        let result = run_stage(&stage.name, &stage.agent, &current_input, ctx).await?;
-
-        current_input.clone_from(&result.output);
-        let output = result.output.clone();
-        stage_results.push(result);
-
-        let state = WorkflowState {
-            version: persistence::WORKFLOW_STATE_VERSION,
-            workflow_name: workflow.name.clone(),
-            completed_stages: stage_results
-                .iter()
-                .map(|r| CompletedStage {
-                    stage_name: r.stage_name.clone(),
-                    agent_name: r.agent_name.clone(),
-                    output: r.output.clone(),
-                    cost_cents: r.cost_cents,
-                    tokens: r.tokens,
-                })
-                .collect(),
-            next_input: current_input.clone(),
-        };
-        save_state(&state, state_path)
-            .map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
-
-        current_stage = resolve_next_stage(workflow, stage, &output)?;
-    }
-
-    clear_state(state_path).map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
-
-    let final_output = stage_results
-        .last()
-        .map(|r| r.output.clone())
-        .unwrap_or_default();
-
-    Ok(build_result(stage_results, final_output))
-}
-
 /// Execute all workflow stages with the trigger as input (fan-out pattern).
 /// Each stage receives the same trigger input independently.
 ///

--- a/src/runtime/workflow/resumable.rs
+++ b/src/runtime/workflow/resumable.rs
@@ -1,0 +1,122 @@
+use std::collections::HashSet;
+
+use crate::ast::WorkflowDef;
+
+use super::persistence;
+use super::{
+    WorkflowContext, WorkflowError, WorkflowResult, build_result, resolve_next_stage, run_stage,
+    StageResult,
+};
+
+fn build_resume_context(
+    checkpoint: Option<&persistence::WorkflowState>,
+    workflow: &WorkflowDef,
+) -> (Vec<StageResult>, String, HashSet<String>) {
+    let default_input = format!("Trigger: {}", workflow.trigger);
+    if let Some(state) = checkpoint.filter(|s| s.workflow_name == workflow.name) {
+        let prior_results = state
+            .completed_stages
+            .iter()
+            .map(|cs| StageResult {
+                stage_name: cs.stage_name.clone(),
+                agent_name: cs.agent_name.clone(),
+                output: cs.output.clone(),
+                cost_cents: cs.cost_cents,
+                tokens: cs.tokens,
+            })
+            .collect();
+        let skip = state
+            .completed_stages
+            .iter()
+            .map(|cs| cs.stage_name.clone())
+            .collect();
+        return (prior_results, state.next_input.clone(), skip);
+    }
+    (Vec::new(), default_input, HashSet::new())
+}
+
+/// Determine the stage to (re)start from given a checkpoint.
+fn find_resume_start<'a>(
+    workflow: &'a WorkflowDef,
+    checkpoint: Option<&persistence::WorkflowState>,
+    skip_stages: &HashSet<String>,
+) -> Result<Option<&'a crate::ast::Stage>, WorkflowError> {
+    if skip_stages.is_empty() {
+        return Ok(workflow.stages.first());
+    }
+    let Some(last_cs) = checkpoint.and_then(|s| s.completed_stages.last()) else {
+        return Ok(workflow.stages.first());
+    };
+    let Some(last_stage) = workflow.find_stage(&last_cs.stage_name) else {
+        return Ok(workflow.stages.first());
+    };
+    resolve_next_stage(workflow, last_stage, &last_cs.output)
+}
+
+/// Execute a workflow sequentially with checkpoint persistence.
+///
+/// After each stage completes, state is saved to `state_path` as JSON.
+/// If a previous state file exists for this workflow, execution resumes
+/// from the last completed stage. On successful completion the state file
+/// is removed.
+///
+/// # Errors
+/// Returns `WorkflowError` if an agent is missing, a stage fails, a route
+/// references a nonexistent stage, circular routing is detected, or state
+/// persistence fails.
+pub async fn run_sequential_resumable(
+    workflow: &WorkflowDef,
+    ctx: &WorkflowContext<'_>,
+    state_path: &std::path::Path,
+) -> Result<WorkflowResult, WorkflowError> {
+    use persistence::{CompletedStage, WorkflowState, clear_state, load_state, save_state};
+
+    let checkpoint =
+        load_state(state_path).map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
+
+    let (mut stage_results, mut current_input, skip_stages) =
+        build_resume_context(checkpoint.as_ref(), workflow);
+    let mut visited: HashSet<&str> = skip_stages.iter().map(String::as_str).collect();
+    let mut current_stage = find_resume_start(workflow, checkpoint.as_ref(), &skip_stages)?;
+
+    while let Some(stage) = current_stage {
+        if !visited.insert(&stage.name) {
+            return Err(WorkflowError::CircularRoute(stage.name.clone()));
+        }
+
+        let result = run_stage(&stage.name, &stage.agent, &current_input, ctx).await?;
+
+        current_input.clone_from(&result.output);
+        let output = result.output.clone();
+        stage_results.push(result);
+
+        let state = WorkflowState {
+            version: persistence::WORKFLOW_STATE_VERSION,
+            workflow_name: workflow.name.clone(),
+            completed_stages: stage_results
+                .iter()
+                .map(|r| CompletedStage {
+                    stage_name: r.stage_name.clone(),
+                    agent_name: r.agent_name.clone(),
+                    output: r.output.clone(),
+                    cost_cents: r.cost_cents,
+                    tokens: r.tokens,
+                })
+                .collect(),
+            next_input: current_input.clone(),
+        };
+        save_state(&state, state_path)
+            .map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
+
+        current_stage = resolve_next_stage(workflow, stage, &output)?;
+    }
+
+    clear_state(state_path).map_err(|e| WorkflowError::PersistenceFailure(e.to_string()))?;
+
+    let final_output = stage_results
+        .last()
+        .map(|r| r.output.clone())
+        .unwrap_or_default();
+
+    Ok(build_result(stage_results, final_output))
+}

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -38,6 +38,7 @@ fn make_workflow(name: &str, trigger: &str, stage_agents: &[&str]) -> WorkflowDe
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
         mode: ExecutionMode::Sequential,
+        schedule: None,
         span: Span::new(0, 1),
     }
 }
@@ -359,7 +360,7 @@ fn make_conditional_workflow() -> (ReinFile, WorkflowDef) {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: Span::new(0, 1),
     };
 
@@ -462,7 +463,7 @@ async fn conditional_no_else_ends_workflow() {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: Span::new(0, 1),
     };
 
@@ -893,7 +894,7 @@ async fn conditional_route_to_nonexistent_stage_errors() {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: Span::new(0, 1),
     };
 
@@ -962,7 +963,7 @@ async fn circular_route_returns_error() {
             route_blocks: vec![],
             parallel_blocks: vec![],
             auto_resolve: None, within_blocks: vec![],
-        mode: ExecutionMode::Sequential,
+        mode: ExecutionMode::Sequential, schedule: None,
         span: Span::new(0, 1),
     };
 
@@ -1014,6 +1015,10 @@ async fn step_execution_runs_agent_with_goal() {
             on_failure: None,
             send_to: None,
             fallback: None,
+            for_each: None,
+            typed_input: None,
+            typed_outputs: vec![],
+            escalate: None,
             span: Span::new(0, 1),
         }],
         route_blocks: vec![],
@@ -1021,6 +1026,7 @@ async fn step_execution_runs_agent_with_goal() {
         auto_resolve: None,
         within_blocks: vec![],
         mode: ExecutionMode::Sequential,
+        schedule: None,
         span: Span::new(0, 1),
     };
 

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -79,7 +79,7 @@ fn zero_budget_detected() {
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile { archetypes: vec![], policies: vec![],
-            observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![],
+            observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
             imports: vec![],
         defaults: None,
         providers: vec![],

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -275,6 +275,7 @@ fn make_workflow(name: &str, trigger: &str, agents: &[&str]) -> WorkflowDef {
             auto_resolve: None,
             within_blocks: vec![],
         mode: ExecutionMode::Sequential,
+        schedule: None,
         span: Span::new(0, 1),
     }
 }


### PR DESCRIPTION
## QA Fixes

- **#227** — Keywords as values: Added `keyword_as_ident()` and `from_word()` to `TokenKind`, simplified `expect_ident()` and `parse_value_expr()` to accept keywords in value positions
- **#228** — Wired `eval_parser`, `memory_parser`, `secrets_parser` into `parse_file()` as top-level blocks; wired `schedule_parser` into workflow body parser (schedule is workflow-level, not top-level)
- **#229** — Removed unused `Constraint` import in engine tests
- **#230** — Split oversized files: lexer (302+325), parser (395), workflow (309+120 resumable)

### Bonus fixes
- All pre-existing clippy warnings fixed (collapsible if, unnecessary semicolon, raw strings, bool-to-int, map_unwrap_or, cast safety)
- Added AST fields for `for_each`, `typed_input`, `typed_outputs`, `escalate` on StepDef with parsing support
- Added `schedule` field to WorkflowDef
- All 440 tests pass, `cargo clippy -- -D warnings` clean

Closes #227
Closes #228
Closes #229
Closes #230