### PR TITLE
feat(parser): for-each iteration, typed step I/O, escalate keyword

### DIFF
--- a/src/parser/step_ext_tests.rs
+++ b/src/parser/step_ext_tests.rs
@@ -37,6 +37,10 @@ fn step_typed_output() {
     let step = &f.workflows[0].steps[0];
     assert_eq!(step.typed_outputs.len(), 1);
     assert_eq!(step.typed_outputs[0].0, "items");
+    assert!(matches!(
+        &step.typed_outputs[0].1,
+        crate::ast::TypeExpr::Named { name, array: true } if name == "Product"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Parser + AST support for step extensions:

- **#131** — `for each: <collection>` iteration binding on steps
- **#132** — Typed step I/O: `input: <name>` and `output: <name>: <Type>`
- **#134** — `escalate to <target> via <channel>("destination")` keyword

All parsing and AST fields implemented with tests. Runtime execution support to follow.

Closes #131
Closes #132
Closes #134