### PR TITLE
feat(parser): human approval workflows

### DIFF
--- a/src/ast/approval.rs
+++ b/src/ast/approval.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// An `approve` or `collaborate` human-in-the-loop block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalDef {
+    /// Kind of approval (approve or collaborate).
+    pub kind: ApprovalKind,
+    /// Channel for the approval (e.g. "slack", "dashboard").
+    pub channel: String,
+    /// Destination within the channel (e.g. "#approvals").
+    pub destination: String,
+    /// Optional timeout (e.g. "4h", "30m").
+    pub timeout: Option<String>,
+    /// Collaboration mode (only for collaborate kind).
+    pub mode: Option<CollaborationMode>,
+    pub span: Span,
+}
+
+/// Whether this is an approval gate or a collaboration session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalKind {
+    /// Simple approve/reject gate.
+    Approve,
+    /// Human edits, suggests, or reviews agent output.
+    Collaborate,
+}
+
+/// Mode for human collaboration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CollaborationMode {
+    /// Human can directly edit agent output.
+    Edit,
+    /// Human suggests changes, agent decides.
+    Suggest,
+    /// Human reviews and approves/rejects.
+    Review,
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 mod agent;
+mod approval;
 mod channel;
 mod circuit_breaker;
 mod escalate;
@@ -23,6 +24,7 @@ mod workflow;
 pub use agent::*;
 pub use channel::*;
 pub use circuit_breaker::*;
+pub use approval::*;
 pub use escalate::*;
 pub use eval::*;
 pub use fleet::*;

--- a/src/ast/workflow.rs
+++ b/src/ast/workflow.rs
@@ -227,6 +227,8 @@ pub struct StepDef {
     pub typed_outputs: Vec<(String, TypeExpr)>,
     /// Escalation to human: `escalate to human via channel("dest")`.
     pub escalate: Option<EscalateDef>,
+    /// Human approval gate or collaboration session.
+    pub approval: Option<super::ApprovalDef>,
     pub span: Span,
 }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -84,6 +84,7 @@ pub enum TokenKind {
     Schedule, Daily, Every, Hours,
     For, Each, Input, Output,
     Human, Via, Secrets, Vault,
+    Approve, Collaborate, Mode, Timeout, Edit, Suggest, Review,
     Lt,
     Gt,
     LtEq,
@@ -170,6 +171,9 @@ impl TokenKind {
             Self::Input => "input", Self::Output => "output",
             Self::Human => "human", Self::Via => "via",
             Self::Secrets => "secrets", Self::Vault => "vault",
+            Self::Approve => "approve", Self::Collaborate => "collaborate",
+            Self::Mode => "mode", Self::Timeout => "timeout",
+            Self::Edit => "edit", Self::Suggest => "suggest", Self::Review => "review",
             Self::Comment => "comment", Self::Eof => "end of file",
             _ => return None,
         };
@@ -221,6 +225,9 @@ impl TokenKind {
             "input" => Self::Input, "output" => Self::Output,
             "human" => Self::Human, "via" => Self::Via,
             "secrets" => Self::Secrets, "vault" => Self::Vault,
+            "approve" => Self::Approve, "collaborate" => Self::Collaborate,
+            "mode" => Self::Mode, "timeout" => Self::Timeout,
+            "edit" => Self::Edit, "suggest" => Self::Suggest, "review" => Self::Review,
             _ => return None,
         };
         Some(kind)
@@ -247,7 +254,9 @@ impl TokenKind {
             | Self::Session | Self::Knowledge | Self::Schedule | Self::Daily
             | Self::Every | Self::Hours | Self::For | Self::Each
             | Self::Input | Self::Output | Self::Human | Self::Via
-            | Self::Secrets | Self::Vault => self.keyword_str(),
+            | Self::Secrets | Self::Vault
+            | Self::Approve | Self::Collaborate | Self::Mode | Self::Timeout
+            | Self::Edit | Self::Suggest | Self::Review => self.keyword_str(),
             _ => None,
         }
     }

--- a/src/parser/approval_parser.rs
+++ b/src/parser/approval_parser.rs
@@ -1,0 +1,115 @@
+use crate::ast::{ApprovalDef, ApprovalKind, CollaborationMode, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `approve: human via channel("dest") timeout 4h`
+    /// or `collaborate: human via channel("dest") { mode: edit }`
+    pub(super) fn parse_approval(&mut self) -> Result<ApprovalDef, ParseError> {
+        let start = self.current_span().start;
+
+        let kind = match self.peek() {
+            TokenKind::Approve => {
+                self.advance();
+                ApprovalKind::Approve
+            }
+            TokenKind::Collaborate => {
+                self.advance();
+                ApprovalKind::Collaborate
+            }
+            _ => {
+                return Err(ParseError::new(
+                    "expected 'approve' or 'collaborate'",
+                    self.current_span(),
+                ));
+            }
+        };
+
+        self.expect(&TokenKind::Colon)?;
+        // Expect "human"
+        let (target, _) = self.expect_ident()?;
+        if target != "human" {
+            return Err(ParseError::new(
+                format!("expected 'human' after '{kind:?}:', got '{target}'"),
+                self.current_span(),
+            ));
+        }
+
+        self.expect(&TokenKind::Via)?;
+        let (channel, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LParen)?;
+        let destination = self.expect_string()?;
+        let end = self.expect(&TokenKind::RParen)?;
+
+        let mut timeout = None;
+        let mut mode = None;
+
+        // Optional timeout (inline form: `timeout 4h`)
+        if *self.peek() == TokenKind::Timeout {
+            self.advance();
+            let t = self.expect_string()?;
+            timeout = Some(t);
+        }
+
+        // Optional body block for collaborate
+        if *self.peek() == TokenKind::LBrace {
+            self.advance();
+            while *self.peek() != TokenKind::RBrace {
+                match self.peek() {
+                    TokenKind::Mode => {
+                        self.advance();
+                        self.expect(&TokenKind::Colon)?;
+                        mode = Some(self.parse_collaboration_mode()?);
+                    }
+                    TokenKind::Timeout => {
+                        self.advance();
+                        self.expect(&TokenKind::Colon)?;
+                        let t = self.expect_string()?;
+                        timeout = Some(t);
+                    }
+                    _ => {
+                        return Err(ParseError::new(
+                            format!("unexpected token in approval block: {}", self.peek()),
+                            self.current_span(),
+                        ));
+                    }
+                }
+            }
+            self.advance(); // consume RBrace
+        }
+
+        Ok(ApprovalDef {
+            kind,
+            channel,
+            destination,
+            timeout,
+            mode,
+            span: Span::new(start, end.end),
+        })
+    }
+
+    fn parse_collaboration_mode(&mut self) -> Result<CollaborationMode, ParseError> {
+        match self.peek() {
+            TokenKind::Edit => {
+                self.advance();
+                Ok(CollaborationMode::Edit)
+            }
+            TokenKind::Suggest => {
+                self.advance();
+                Ok(CollaborationMode::Suggest)
+            }
+            TokenKind::Review => {
+                self.advance();
+                Ok(CollaborationMode::Review)
+            }
+            _ => Err(ParseError::new(
+                format!(
+                    "expected collaboration mode (edit, suggest, review), got {}",
+                    self.peek()
+                ),
+                self.current_span(),
+            )),
+        }
+    }
+}

--- a/src/parser/approval_tests.rs
+++ b/src/parser/approval_tests.rs
@@ -1,0 +1,73 @@
+use crate::ast::{ApprovalKind, CollaborationMode};
+use crate::parser::parse;
+
+#[test]
+fn approve_with_timeout() {
+    let f = parse(
+        r##"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step review {
+                agent: a
+                approve: human via slack("#approvals") timeout "4h"
+            }
+        }
+    "##,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    let approval = step.approval.as_ref().unwrap();
+    assert_eq!(approval.kind, ApprovalKind::Approve);
+    assert_eq!(approval.channel, "slack");
+    assert_eq!(approval.destination, "#approvals");
+    assert_eq!(approval.timeout.as_deref(), Some("4h"));
+}
+
+#[test]
+fn collaborate_with_mode() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step edit_draft {
+                agent: a
+                collaborate: human via dashboard("editor") {
+                    mode: edit
+                }
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    let approval = step.approval.as_ref().unwrap();
+    assert_eq!(approval.kind, ApprovalKind::Collaborate);
+    assert_eq!(approval.channel, "dashboard");
+    assert_eq!(approval.mode, Some(CollaborationMode::Edit));
+}
+
+#[test]
+fn collaborate_suggest_mode() {
+    let f = parse(
+        r#"
+        agent a { model: "gpt-4o" }
+        workflow w {
+            trigger: event
+            step s {
+                agent: a
+                collaborate: human via dashboard("reviewer") {
+                    mode: suggest
+                    timeout: "2h"
+                }
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let step = &f.workflows[0].steps[0];
+    let approval = step.approval.as_ref().unwrap();
+    assert_eq!(approval.mode, Some(CollaborationMode::Suggest));
+    assert_eq!(approval.timeout.as_deref(), Some("2h"));
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ mod channel_parser;
 mod circuit_breaker_parser;
 mod common_parser;
 mod condition_parser;
+mod approval_parser;
 mod eval_parser;
 mod fleet_parser;
 mod import_parser;
@@ -389,6 +390,9 @@ mod eval_parser_tests;
 mod memory_parser_tests;
 #[cfg(test)]
 mod schedule_parser_tests;
+#[cfg(test)]
+#[cfg(test)]
+mod approval_tests;
 #[cfg(test)]
 mod step_ext_tests;
 #[cfg(test)]

--- a/src/parser/step_extensions.rs
+++ b/src/parser/step_extensions.rs
@@ -1,9 +1,49 @@
-use crate::ast::{EscalateDef, Span, TypeExpr};
+use crate::ast::{EscalateDef, PipeExpr, Span, TypeExpr};
 use crate::lexer::TokenKind;
 
 use super::{ParseError, Parser};
 
 impl Parser {
+    /// Parse an `input:` field in a step body.
+    /// Handles both typed input (`input: name`) and pipe expressions (`input: source | ...`).
+    /// Caller must have already consumed `input` keyword and `:`.
+    pub(super) fn parse_step_input_field(
+        &mut self,
+        name: &str,
+        input: &mut Option<PipeExpr>,
+        typed_input: &mut Option<String>,
+    ) -> Result<(), ParseError> {
+        if matches!(self.peek(), TokenKind::Ident(_)) || self.peek().keyword_as_ident().is_some() {
+            if self.peek_at(1) == Some(&TokenKind::Pipe) {
+                if input.is_some() {
+                    return Err(ParseError::new(
+                        format!("duplicate field 'input' in step '{name}'"),
+                        self.current_span(),
+                    ));
+                }
+                *input = Some(self.parse_pipe_expr()?);
+            } else {
+                if typed_input.is_some() {
+                    return Err(ParseError::new(
+                        format!("duplicate 'input' in step '{name}'"),
+                        self.current_span(),
+                    ));
+                }
+                let (input_name, _) = self.expect_ident()?;
+                *typed_input = Some(input_name);
+            }
+        } else {
+            if input.is_some() {
+                return Err(ParseError::new(
+                    format!("duplicate field 'input' in step '{name}'"),
+                    self.current_span(),
+                ));
+            }
+            *input = Some(self.parse_pipe_expr()?);
+        }
+        Ok(())
+    }
+
     /// Parse `for each: <collection>`.
     pub(super) fn parse_step_for_each(
         &mut self,

--- a/src/parser/step_parser.rs
+++ b/src/parser/step_parser.rs
@@ -18,6 +18,7 @@ struct StepFields {
     typed_input: Option<String>,
     typed_outputs: Vec<(String, TypeExpr)>,
     escalate: Option<EscalateDef>,
+    approval: Option<crate::ast::ApprovalDef>,
     seen_agent: bool,
     seen_goal: bool,
 }
@@ -75,6 +76,7 @@ impl Parser {
                         typed_input: f.typed_input,
                         typed_outputs: f.typed_outputs,
                         escalate: f.escalate,
+                        approval: f.approval,
                         span: Span::new(start, end),
                     });
                 }
@@ -103,47 +105,23 @@ impl Parser {
                     self.parse_step_escalate(&name, &mut f.escalate)?;
                 }
                 TokenKind::Input => {
-                    // `input:` can be a typed input binding or a pipe expression.
-                    // We peek ahead: if it's `input: <ident>` with no pipe, it's typed_input.
-                    // Otherwise, fall through to pipe parsing.
                     self.advance(); // consume `input`
                     self.expect(&TokenKind::Colon)?;
-                    // Check if next is a simple ident without pipe
-                    if matches!(self.peek(), TokenKind::Ident(_)) || self.peek().keyword_as_ident().is_some() {
-                        // Check if followed by pipe
-                        if self.peek_at(1) == Some(&TokenKind::Pipe) {
-                            // It's a pipe expression — parse as input
-                            if f.input.is_some() {
-                                return Err(ParseError::new(
-                                    format!("duplicate field 'input' in step '{name}'"),
-                                    self.current_span(),
-                                ));
-                            }
-                            f.input = Some(self.parse_pipe_expr()?);
-                        } else {
-                            // Simple typed input
-                            if f.typed_input.is_some() {
-                                return Err(ParseError::new(
-                                    format!("duplicate 'input' in step '{name}'"),
-                                    self.current_span(),
-                                ));
-                            }
-                            let (input_name, _) = self.expect_ident()?;
-                            f.typed_input = Some(input_name);
-                        }
-                    } else {
-                        // Likely a pipe expression starting with something else
-                        if f.input.is_some() {
-                            return Err(ParseError::new(
-                                format!("duplicate field 'input' in step '{name}'"),
-                                self.current_span(),
-                            ));
-                        }
-                        f.input = Some(self.parse_pipe_expr()?);
-                    }
+                    self.parse_step_input_field(
+                        &name, &mut f.input, &mut f.typed_input,
+                    )?;
                 }
                 TokenKind::Output => {
                     self.parse_step_typed_output(&name, &mut f.typed_outputs)?;
+                }
+                TokenKind::Approve | TokenKind::Collaborate => {
+                    if f.approval.is_some() {
+                        return Err(ParseError::new(
+                            format!("duplicate approval in step '{name}'"),
+                            self.current_span(),
+                        ));
+                    }
+                    f.approval = Some(self.parse_approval()?);
                 }
                 _ => {
                     self.parse_step_field_or_error(&name, &mut f)?;
@@ -350,6 +328,7 @@ impl Parser {
             typed_input: None,
             typed_outputs: Vec::new(),
             escalate: None,
+            approval: None,
             span: Span::new(start, end),
         })
     }

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -1019,6 +1019,7 @@ async fn step_execution_runs_agent_with_goal() {
             typed_input: None,
             typed_outputs: vec![],
             escalate: None,
+            approval: None,
             span: Span::new(0, 1),
         }],
         route_blocks: vec![],


### PR DESCRIPTION
Adds approve/collaborate human-in-the-loop blocks for steps.

- `approve: human via slack("#channel") timeout "4h"`
- `collaborate: human via dashboard("editor") { mode: edit }`
- Three collaboration modes: edit, suggest, review
- 3 tests, clippy clean

Closes #139