### PR TITLE
feat(parser): consensus blocks and scenario test blocks

### DIFF
--- a/src/ast/consensus.rs
+++ b/src/ast/consensus.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// A `consensus <name> { ... }` block for multi-agent verification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConsensusDef {
+    pub name: String,
+    /// List of agent names participating.
+    pub agents: Vec<String>,
+    /// Consensus strategy (majority, unanimous, etc.).
+    pub strategy: ConsensusStrategy,
+    /// Required agreement threshold (e.g. 2 of 3).
+    pub require: Option<ConsensusRequirement>,
+    pub span: Span,
+}
+
+/// Strategy for reaching consensus.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsensusStrategy {
+    Majority,
+    Unanimous,
+    Custom(String),
+}
+
+/// Agreement requirement: `N of M agree`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConsensusRequirement {
+    pub required: u32,
+    pub total: u32,
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6,6 +6,7 @@ mod agent;
 mod approval;
 mod channel;
 mod circuit_breaker;
+mod consensus;
 mod escalate;
 mod eval;
 mod fleet;
@@ -15,6 +16,7 @@ mod observe;
 mod pipe;
 mod policy;
 mod provider;
+mod scenario;
 mod schedule;
 mod secrets;
 mod types;
@@ -24,6 +26,7 @@ mod workflow;
 pub use agent::*;
 pub use channel::*;
 pub use circuit_breaker::*;
+pub use consensus::*;
 pub use approval::*;
 pub use escalate::*;
 pub use eval::*;
@@ -34,6 +37,7 @@ pub use observe::*;
 pub use pipe::*;
 pub use policy::*;
 pub use provider::*;
+pub use scenario::*;
 pub use schedule::*;
 pub use secrets::*;
 pub use types::*;
@@ -76,6 +80,8 @@ pub struct ReinFile {
     pub evals: Vec<EvalDef>,
     pub memories: Vec<MemoryDef>,
     pub secrets: Vec<SecretsDef>,
+    pub consensus_blocks: Vec<ConsensusDef>,
+    pub scenarios: Vec<ScenarioDef>,
 }
 
 #[cfg(test)]

--- a/src/ast/scenario.rs
+++ b/src/ast/scenario.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use super::Span;
+
+/// A `scenario <name> { given { ... } expect { ... } }` test block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScenarioDef {
+    pub name: String,
+    /// Key-value pairs for the given context.
+    pub given: Vec<(String, String)>,
+    /// Expected outcomes.
+    pub expect: Vec<(String, String)>,
+    pub span: Span,
+}

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -102,7 +102,7 @@ fn agent_def_full_serializes() {
 
 #[test]
 fn rein_file_roundtrips_via_json() {
-    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
+    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![], consensus_blocks: vec![], scenarios: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],
@@ -223,7 +223,7 @@ fn workflow_roundtrips_via_json() {
 
 #[test]
 fn rein_file_with_workflows_roundtrips() {
-    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
+    let file = ReinFile { archetypes: vec![], policies: vec![], observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![], consensus_blocks: vec![], scenarios: vec![],
         imports: vec![],
         defaults: None,
         providers: vec![],

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -85,6 +85,8 @@ pub enum TokenKind {
     For, Each, Input, Output,
     Human, Via, Secrets, Vault,
     Approve, Collaborate, Mode, Timeout, Edit, Suggest, Review,
+    Consensus, Strategy, Majority, Unanimous, Require, Agree,
+    Scenario, Given, Expect,
     Lt,
     Gt,
     LtEq,
@@ -174,6 +176,10 @@ impl TokenKind {
             Self::Approve => "approve", Self::Collaborate => "collaborate",
             Self::Mode => "mode", Self::Timeout => "timeout",
             Self::Edit => "edit", Self::Suggest => "suggest", Self::Review => "review",
+            Self::Consensus => "consensus", Self::Strategy => "strategy",
+            Self::Majority => "majority", Self::Unanimous => "unanimous",
+            Self::Require => "require", Self::Agree => "agree",
+            Self::Scenario => "scenario", Self::Given => "given", Self::Expect => "expect",
             Self::Comment => "comment", Self::Eof => "end of file",
             _ => return None,
         };
@@ -228,6 +234,10 @@ impl TokenKind {
             "approve" => Self::Approve, "collaborate" => Self::Collaborate,
             "mode" => Self::Mode, "timeout" => Self::Timeout,
             "edit" => Self::Edit, "suggest" => Self::Suggest, "review" => Self::Review,
+            "consensus" => Self::Consensus, "strategy" => Self::Strategy,
+            "majority" => Self::Majority, "unanimous" => Self::Unanimous,
+            "require" => Self::Require, "agree" => Self::Agree,
+            "scenario" => Self::Scenario, "given" => Self::Given, "expect" => Self::Expect,
             _ => return None,
         };
         Some(kind)
@@ -256,7 +266,10 @@ impl TokenKind {
             | Self::Input | Self::Output | Self::Human | Self::Via
             | Self::Secrets | Self::Vault
             | Self::Approve | Self::Collaborate | Self::Mode | Self::Timeout
-            | Self::Edit | Self::Suggest | Self::Review => self.keyword_str(),
+            | Self::Edit | Self::Suggest | Self::Review
+            | Self::Consensus | Self::Strategy | Self::Majority | Self::Unanimous
+            | Self::Require | Self::Agree | Self::Scenario | Self::Given
+            | Self::Expect => self.keyword_str(),
             _ => None,
         }
     }

--- a/src/parser/consensus_parser.rs
+++ b/src/parser/consensus_parser.rs
@@ -1,0 +1,83 @@
+use crate::ast::{ConsensusDef, ConsensusRequirement, ConsensusStrategy, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `consensus <name> { agents: [...], strategy: majority, require: N of M agree }`
+    pub(super) fn parse_consensus(&mut self) -> Result<ConsensusDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Consensus)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut agents = Vec::new();
+        let mut strategy = None;
+        let mut require = None;
+
+        while *self.peek() != TokenKind::RBrace {
+            self.skip_comments();
+            match self.peek() {
+                TokenKind::Agents => {
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    agents = self.parse_ident_list()?;
+                }
+                TokenKind::Strategy => {
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    strategy = Some(self.parse_consensus_strategy()?);
+                }
+                TokenKind::Require => {
+                    self.advance();
+                    self.expect(&TokenKind::Colon)?;
+                    require = Some(self.parse_consensus_requirement()?);
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        format!("unexpected token in consensus block: {}", self.peek()),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.advance(); // consume RBrace
+
+        Ok(ConsensusDef {
+            name,
+            agents,
+            strategy: strategy.unwrap_or(ConsensusStrategy::Majority),
+            require,
+            span: Span::new(start, end),
+        })
+    }
+
+    fn parse_consensus_strategy(&mut self) -> Result<ConsensusStrategy, ParseError> {
+        match self.peek() {
+            TokenKind::Majority => {
+                self.advance();
+                Ok(ConsensusStrategy::Majority)
+            }
+            TokenKind::Unanimous => {
+                self.advance();
+                Ok(ConsensusStrategy::Unanimous)
+            }
+            _ => {
+                let (name, _) = self.expect_ident()?;
+                Ok(ConsensusStrategy::Custom(name))
+            }
+        }
+    }
+
+    /// Parse `N of M agree`.
+    fn parse_consensus_requirement(&mut self) -> Result<ConsensusRequirement, ParseError> {
+        let required = u32::try_from(self.expect_integer()?).unwrap_or(u32::MAX);
+        self.expect(&TokenKind::Of)?;
+        let total = u32::try_from(self.expect_integer()?).unwrap_or(u32::MAX);
+        self.expect(&TokenKind::Agree)?;
+        Ok(ConsensusRequirement { required, total })
+    }
+
+}

--- a/src/parser/consensus_tests.rs
+++ b/src/parser/consensus_tests.rs
@@ -1,0 +1,39 @@
+use crate::ast::{ConsensusStrategy};
+use crate::parser::parse;
+
+#[test]
+fn consensus_majority() {
+    let f = parse(
+        r#"
+        consensus refund_review {
+            agents: [reviewer_a, reviewer_b, reviewer_c]
+            strategy: majority
+            require: 2 of 3 agree
+        }
+    "#,
+    )
+    .unwrap();
+    let c = &f.consensus_blocks[0];
+    assert_eq!(c.name, "refund_review");
+    assert_eq!(c.agents, vec!["reviewer_a", "reviewer_b", "reviewer_c"]);
+    assert_eq!(c.strategy, ConsensusStrategy::Majority);
+    let req = c.require.as_ref().unwrap();
+    assert_eq!(req.required, 2);
+    assert_eq!(req.total, 3);
+}
+
+#[test]
+fn consensus_unanimous_no_require() {
+    let f = parse(
+        r#"
+        consensus approval {
+            agents: [a, b]
+            strategy: unanimous
+        }
+    "#,
+    )
+    .unwrap();
+    let c = &f.consensus_blocks[0];
+    assert_eq!(c.strategy, ConsensusStrategy::Unanimous);
+    assert!(c.require.is_none());
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,6 +7,7 @@ mod circuit_breaker_parser;
 mod common_parser;
 mod condition_parser;
 mod approval_parser;
+mod consensus_parser;
 mod eval_parser;
 mod fleet_parser;
 mod import_parser;
@@ -15,6 +16,7 @@ mod observe_parser;
 mod pipe_parser;
 mod policy_parser;
 mod schedule_parser;
+mod scenario_parser;
 mod secrets_parser;
 mod step_extensions;
 mod step_parser;
@@ -281,6 +283,22 @@ impl Parser {
         }
     }
 
+    fn expect_integer(&mut self) -> Result<u64, ParseError> {
+        match self.peek().clone() {
+            TokenKind::Number(n) => {
+                let val = n.parse::<u64>().map_err(|_| {
+                    ParseError::new(format!("expected integer, got '{n}'"), self.current_span())
+                })?;
+                self.advance();
+                Ok(val)
+            }
+            other => Err(ParseError::new(
+                format!("expected integer, got {other}"),
+                self.current_span(),
+            )),
+        }
+    }
+
     fn expect_currency(&mut self) -> Result<(u64, char, Span), ParseError> {
         self.skip_comments();
         let tok = self.current().clone();
@@ -316,6 +334,8 @@ impl Parser {
         let mut evals = Vec::new();
         let mut memories = Vec::new();
         let mut secrets = Vec::new();
+        let mut consensus_blocks = Vec::new();
+        let mut scenarios = Vec::new();
         while self.peek() != &TokenKind::Eof {
             match self.peek() {
                 TokenKind::Import => imports.push(self.parse_import()?),
@@ -350,6 +370,8 @@ impl Parser {
                     ));
                 }
                 TokenKind::Secrets => secrets.push(self.parse_secrets()?),
+                TokenKind::Consensus => consensus_blocks.push(self.parse_consensus()?),
+                TokenKind::Scenario => scenarios.push(self.parse_scenario()?),
                 other => {
                     return Err(ParseError::new(
                         format!(
@@ -378,6 +400,8 @@ impl Parser {
             evals,
             memories,
             secrets,
+            consensus_blocks,
+            scenarios,
         })
     }
 }
@@ -393,6 +417,10 @@ mod schedule_parser_tests;
 #[cfg(test)]
 #[cfg(test)]
 mod approval_tests;
+#[cfg(test)]
+mod consensus_tests;
+#[cfg(test)]
+mod scenario_tests;
 #[cfg(test)]
 mod step_ext_tests;
 #[cfg(test)]

--- a/src/parser/scenario_parser.rs
+++ b/src/parser/scenario_parser.rs
@@ -1,0 +1,70 @@
+use crate::ast::{ScenarioDef, Span};
+use crate::lexer::TokenKind;
+
+use super::{ParseError, Parser};
+
+impl Parser {
+    /// Parse `scenario <name> { given { ... } expect { ... } }`
+    pub(super) fn parse_scenario(&mut self) -> Result<ScenarioDef, ParseError> {
+        let start = self.current_span().start;
+        self.expect(&TokenKind::Scenario)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut given = Vec::new();
+        let mut expect = Vec::new();
+
+        while *self.peek() != TokenKind::RBrace {
+            self.skip_comments();
+            match self.peek() {
+                TokenKind::Given => {
+                    self.advance();
+                    self.expect(&TokenKind::LBrace)?;
+                    given = self.parse_key_value_pairs()?;
+                    self.expect(&TokenKind::RBrace)?;
+                }
+                TokenKind::Expect => {
+                    self.advance();
+                    self.expect(&TokenKind::LBrace)?;
+                    expect = self.parse_key_value_pairs()?;
+                    self.expect(&TokenKind::RBrace)?;
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        format!("expected 'given' or 'expect', got {}", self.peek()),
+                        self.current_span(),
+                    ));
+                }
+            }
+        }
+
+        let end = self.current_span().end;
+        self.advance(); // consume RBrace
+
+        Ok(ScenarioDef {
+            name,
+            given,
+            expect,
+            span: Span::new(start, end),
+        })
+    }
+
+    /// Parse key-value pairs like `key: "value"` or `key: value`.
+    fn parse_key_value_pairs(&mut self) -> Result<Vec<(String, String)>, ParseError> {
+        let mut pairs = Vec::new();
+        while *self.peek() != TokenKind::RBrace {
+            self.skip_comments();
+            let (key, _) = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let value = if let TokenKind::StringLiteral(s) = self.peek().clone() {
+                self.advance();
+                s
+            } else {
+                let (v, _) = self.expect_ident()?;
+                v
+            };
+            pairs.push((key, value));
+        }
+        Ok(pairs)
+    }
+}

--- a/src/parser/scenario_tests.rs
+++ b/src/parser/scenario_tests.rs
@@ -1,0 +1,46 @@
+use crate::parser::parse;
+
+#[test]
+fn scenario_basic() {
+    let f = parse(
+        r#"
+        scenario angry_customer {
+            given {
+                sentiment: "angry"
+                category: "billing"
+            }
+            expect {
+                action: "refund"
+                channel: "zendesk"
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let s = &f.scenarios[0];
+    assert_eq!(s.name, "angry_customer");
+    assert_eq!(s.given.len(), 2);
+    assert_eq!(s.given[0], ("sentiment".to_string(), "angry".to_string()));
+    assert_eq!(s.expect.len(), 2);
+    assert_eq!(s.expect[0], ("action".to_string(), "refund".to_string()));
+}
+
+#[test]
+fn scenario_ident_values() {
+    let f = parse(
+        r#"
+        scenario quick_reply {
+            given {
+                priority: low
+            }
+            expect {
+                action: auto_respond
+            }
+        }
+    "#,
+    )
+    .unwrap();
+    let s = &f.scenarios[0];
+    assert_eq!(s.given[0], ("priority".to_string(), "low".to_string()));
+    assert_eq!(s.expect[0], ("action".to_string(), "auto_respond".to_string()));
+}

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -79,7 +79,7 @@ fn zero_budget_detected() {
     // directly. amount is u64 (cents), so 0 is the only invalid value.
     use crate::ast::{AgentDef, Budget, ReinFile, Span};
     let file = ReinFile { archetypes: vec![], policies: vec![],
-            observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![],
+            observes: vec![], fleets: vec![], channels: vec![], circuit_breakers: vec![], evals: vec![], memories: vec![], secrets: vec![], consensus_blocks: vec![], scenarios: vec![],
             imports: vec![],
         defaults: None,
         providers: vec![],


### PR DESCRIPTION
Multi-agent consensus verification and scenario test definitions.

- `consensus <name> { agents: [...], strategy: majority, require: N of M agree }`
- `scenario <name> { given { ... } expect { ... } }`
- 4 tests, clippy clean, 454 total tests passing

Closes #145
Closes #146