### PR TITLE
feat(server): REST API server with axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1170,7 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "dotenvy",
@@ -1122,6 +1181,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tower",
+ "tower-http",
  "wiremock",
 ]
 
@@ -1322,6 +1383,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1591,6 +1663,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1629,6 +1702,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ async-trait = "0.1.89"
 regex = "1.12.3"
 toml = "0.8"
 chrono = { version = "0.4.43", features = ["serde"] }
+axum = { version = "0.8.8", features = ["json"] }
+tower-http = { version = "0.6.8", features = ["cors"] }
+tower = { version = "0.5.3", features = ["util"] }
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod error;
 pub mod lexer;
 pub mod parser;
 pub mod runtime;
+pub mod server;
 pub mod validator;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,41 @@
+//! REST API server for Rein.
+//!
+//! Provides HTTP endpoints for triggering workflows, listing agents,
+//! querying the audit log, and health checks.
+
+mod routes;
+
+#[cfg(test)]
+mod tests;
+
+use axum::Router;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+
+use crate::ast::ReinFile;
+use crate::runtime::audit::AuditLog;
+
+/// Shared application state for the API server.
+pub struct AppState {
+    /// The parsed .rein file(s).
+    pub rein_file: ReinFile,
+    /// The audit log.
+    pub audit_log: Option<AuditLog>,
+}
+
+/// Build the Axum router with all API routes.
+pub fn build_router(state: Arc<AppState>) -> Router {
+    routes::build(state).layer(CorsLayer::permissive())
+}
+
+/// Start the API server on the given address.
+///
+/// # Errors
+/// Returns an error if the server fails to bind or serve.
+pub async fn serve(state: Arc<AppState>, addr: SocketAddr) -> Result<(), std::io::Error> {
+    let app = build_router(state);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,0 +1,157 @@
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::get,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::AppState;
+
+/// Build all API routes.
+pub fn build(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/api/v1/agents", get(list_agents))
+        .route("/api/v1/workflows", get(list_workflows))
+        .route("/api/v1/types", get(list_types))
+        .route("/api/v1/audit", get(query_audit))
+        .with_state(state)
+}
+
+// ── Health ──────────────────────────────────────────────────────────────
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    version: String,
+}
+
+// ── Agents ──────────────────────────────────────────────────────────────
+
+async fn list_agents(State(state): State<Arc<AppState>>) -> Json<AgentsResponse> {
+    let agents: Vec<AgentSummary> = state
+        .rein_file
+        .agents
+        .iter()
+        .map(|a| AgentSummary {
+            name: a.name.clone(),
+            model: a.model.as_ref().map_or_else(String::new, |m| match m {
+                crate::ast::ValueExpr::Literal(s) => s.clone(),
+                crate::ast::ValueExpr::EnvRef { var_name, .. } => format!("env({var_name})"),
+            }),
+            capabilities: a.can.iter().map(|c| format!("{}.{}", c.namespace, c.action)).collect(),
+        })
+        .collect();
+    Json(AgentsResponse { agents })
+}
+
+#[derive(Serialize)]
+struct AgentsResponse {
+    agents: Vec<AgentSummary>,
+}
+
+#[derive(Serialize)]
+struct AgentSummary {
+    name: String,
+    model: String,
+    capabilities: Vec<String>,
+}
+
+// ── Workflows ───────────────────────────────────────────────────────────
+
+async fn list_workflows(State(state): State<Arc<AppState>>) -> Json<WorkflowsResponse> {
+    let workflows: Vec<WorkflowSummary> = state
+        .rein_file
+        .workflows
+        .iter()
+        .map(|w| WorkflowSummary {
+            name: w.name.clone(),
+            trigger: w.trigger.clone(),
+            stages: w.stages.iter().map(|s| s.name.clone()).collect(),
+            steps: w.steps.iter().map(|s| s.name.clone()).collect(),
+        })
+        .collect();
+    Json(WorkflowsResponse { workflows })
+}
+
+#[derive(Serialize)]
+struct WorkflowsResponse {
+    workflows: Vec<WorkflowSummary>,
+}
+
+#[derive(Serialize)]
+struct WorkflowSummary {
+    name: String,
+    trigger: String,
+    stages: Vec<String>,
+    steps: Vec<String>,
+}
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+async fn list_types(State(state): State<Arc<AppState>>) -> Json<TypesResponse> {
+    let types: Vec<TypeSummary> = state
+        .rein_file
+        .types
+        .iter()
+        .map(|t| TypeSummary {
+            name: t.name.clone(),
+            fields: t.fields.iter().map(|f| f.name.clone()).collect(),
+        })
+        .collect();
+    Json(TypesResponse { types })
+}
+
+#[derive(Serialize)]
+struct TypesResponse {
+    types: Vec<TypeSummary>,
+}
+
+#[derive(Serialize)]
+struct TypeSummary {
+    name: String,
+    fields: Vec<String>,
+}
+
+// ── Audit ───────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct AuditQuery {
+    workflow: Option<String>,
+    limit: Option<usize>,
+}
+
+async fn query_audit(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(query): axum::extract::Query<AuditQuery>,
+) -> Result<Json<AuditResponse>, StatusCode> {
+    let Some(ref audit_log) = state.audit_log else {
+        return Ok(Json(AuditResponse { entries: vec![] }));
+    };
+
+    let entries = if let Some(ref wf) = query.workflow {
+        audit_log.query_by_workflow(wf)
+    } else {
+        audit_log.read_all()
+    }
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let limit = query.limit.unwrap_or(100);
+    let entries: Vec<_> = entries.into_iter().take(limit).collect();
+
+    Ok(Json(AuditResponse { entries }))
+}
+
+#[derive(Serialize)]
+struct AuditResponse {
+    entries: Vec<crate::runtime::audit::AuditEntry>,
+}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1,0 +1,110 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use crate::ast::ReinFile;
+use crate::parser::parse;
+
+use super::{AppState, build_router};
+
+fn test_state() -> Arc<AppState> {
+    let rein_file = parse(
+        r#"
+        agent triage { model: "gpt-4o" can [tools.classify] }
+        agent writer { model: "claude-3" }
+        workflow support {
+            trigger: new_ticket
+            step classify { agent: triage }
+            step respond { agent: writer }
+        }
+    "#,
+    )
+    .unwrap();
+    Arc::new(AppState {
+        rein_file,
+        audit_log: None,
+    })
+}
+
+#[tokio::test]
+async fn health_endpoint() {
+    let app = build_router(test_state());
+    let resp = app
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn list_agents_endpoint() {
+    let app = build_router(test_state());
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/agents")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let agents = json["agents"].as_array().unwrap();
+    assert_eq!(agents.len(), 2);
+    assert_eq!(agents[0]["name"], "triage");
+}
+
+#[tokio::test]
+async fn list_workflows_endpoint() {
+    let app = build_router(test_state());
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/workflows")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let workflows = json["workflows"].as_array().unwrap();
+    assert_eq!(workflows.len(), 1);
+    assert_eq!(workflows[0]["name"], "support");
+}
+
+#[tokio::test]
+async fn audit_empty() {
+    let app = build_router(test_state());
+    let resp = app
+        .oneshot(
+            Request::get("/api/v1/audit")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["entries"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn not_found() {
+    let app = build_router(test_state());
+    let resp = app
+        .oneshot(
+            Request::get("/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
HTTP API server for Rein with endpoints:

- `GET /health` — health check with version
- `GET /api/v1/agents` — list agents with capabilities
- `GET /api/v1/workflows` — list workflows with stages/steps
- `GET /api/v1/types` — list type definitions
- `GET /api/v1/audit?workflow=X&limit=N` — query audit log

Built with axum + tower-http CORS. 5 tests.

Closes #157