### PR TITLE
feat(runtime): webhooks, events, observability, alerting, tool registry

### DIFF
--- a/src/runtime/alerting/mod.rs
+++ b/src/runtime/alerting/mod.rs
@@ -1,0 +1,98 @@
+//! Alerting system for workflow anomalies and threshold violations.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod tests;
+
+/// An alert rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertRule {
+    pub name: String,
+    pub condition: AlertCondition,
+    pub severity: Severity,
+    pub channel: String,
+}
+
+/// Alert condition types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AlertCondition {
+    /// Metric exceeds threshold.
+    ThresholdExceeded { metric: String, threshold: f64 },
+    /// Error rate exceeds percentage.
+    ErrorRate { threshold_pct: f64 },
+    /// No events received within duration.
+    Silence { duration_secs: u64 },
+}
+
+/// Alert severity levels.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Info,
+    Warning,
+    Critical,
+}
+
+/// A fired alert.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FiredAlert {
+    pub rule_name: String,
+    pub severity: Severity,
+    pub message: String,
+    pub timestamp_ms: u64,
+}
+
+/// Alert evaluator.
+#[derive(Debug, Default)]
+pub struct AlertEngine {
+    rules: Vec<AlertRule>,
+    fired: Vec<FiredAlert>,
+}
+
+impl AlertEngine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an alert rule.
+    pub fn add_rule(&mut self, rule: AlertRule) {
+        self.rules.push(rule);
+    }
+
+    /// Evaluate a metric value against threshold rules.
+    pub fn evaluate_metric(&mut self, metric: &str, value: f64) {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis().try_into().unwrap_or(u64::MAX);
+
+        for rule in &self.rules {
+            if let AlertCondition::ThresholdExceeded {
+                metric: rule_metric,
+                threshold,
+            } = &rule.condition
+                && rule_metric == metric
+                && value > *threshold
+            {
+                self.fired.push(FiredAlert {
+                    rule_name: rule.name.clone(),
+                    severity: rule.severity.clone(),
+                    message: format!("{metric} = {value} exceeds threshold {threshold}"),
+                    timestamp_ms: ts,
+                });
+            }
+        }
+    }
+
+    /// Get all fired alerts.
+    pub fn fired_alerts(&self) -> &[FiredAlert] {
+        &self.fired
+    }
+
+    /// Clear fired alerts.
+    pub fn clear(&mut self) {
+        self.fired.clear();
+    }
+}

--- a/src/runtime/alerting/tests.rs
+++ b/src/runtime/alerting/tests.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+#[test]
+fn threshold_fires() {
+    let mut engine = AlertEngine::new();
+    engine.add_rule(AlertRule {
+        name: "high_latency".to_string(),
+        condition: AlertCondition::ThresholdExceeded {
+            metric: "step_duration_ms".to_string(),
+            threshold: 1000.0,
+        },
+        severity: Severity::Warning,
+        channel: "slack".to_string(),
+    });
+
+    engine.evaluate_metric("step_duration_ms", 500.0);
+    assert!(engine.fired_alerts().is_empty());
+
+    engine.evaluate_metric("step_duration_ms", 1500.0);
+    assert_eq!(engine.fired_alerts().len(), 1);
+    assert_eq!(engine.fired_alerts()[0].severity, Severity::Warning);
+}
+
+#[test]
+fn non_matching_metric_ignored() {
+    let mut engine = AlertEngine::new();
+    engine.add_rule(AlertRule {
+        name: "r".to_string(),
+        condition: AlertCondition::ThresholdExceeded {
+            metric: "errors".to_string(),
+            threshold: 10.0,
+        },
+        severity: Severity::Critical,
+        channel: "pager".to_string(),
+    });
+    engine.evaluate_metric("latency", 9999.0);
+    assert!(engine.fired_alerts().is_empty());
+}
+
+#[test]
+fn clear_alerts() {
+    let mut engine = AlertEngine::new();
+    engine.add_rule(AlertRule {
+        name: "r".to_string(),
+        condition: AlertCondition::ThresholdExceeded {
+            metric: "m".to_string(),
+            threshold: 0.0,
+        },
+        severity: Severity::Info,
+        channel: "log".to_string(),
+    });
+    engine.evaluate_metric("m", 1.0);
+    assert_eq!(engine.fired_alerts().len(), 1);
+    engine.clear();
+    assert!(engine.fired_alerts().is_empty());
+}

--- a/src/runtime/events/mod.rs
+++ b/src/runtime/events/mod.rs
@@ -1,0 +1,84 @@
+//! Event streaming for workflow and agent lifecycle events.
+
+use serde::{Deserialize, Serialize};
+use std::sync::mpsc;
+
+#[cfg(test)]
+mod tests;
+
+/// A runtime event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    pub kind: EventKind,
+    pub source: String,
+    pub data: serde_json::Value,
+    pub timestamp_ms: u64,
+}
+
+/// Event categories.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    WorkflowStarted,
+    WorkflowCompleted,
+    WorkflowFailed,
+    StepStarted,
+    StepCompleted,
+    StepFailed,
+    AgentInvoked,
+    ToolCalled,
+    GuardrailTriggered,
+    EscalationRaised,
+}
+
+/// Simple in-process event bus.
+pub struct EventBus {
+    sender: mpsc::Sender<Event>,
+    receiver: mpsc::Receiver<Event>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::channel();
+        Self { sender, receiver }
+    }
+
+    /// Get a sender handle that can be cloned for multiple producers.
+    pub fn sender(&self) -> mpsc::Sender<Event> {
+        self.sender.clone()
+    }
+
+    /// Emit an event.
+    pub fn emit(&self, event: Event) -> Result<(), mpsc::SendError<Event>> {
+        self.sender.send(event)
+    }
+
+    /// Drain all pending events.
+    pub fn drain(&self) -> Vec<Event> {
+        let mut events = Vec::new();
+        while let Ok(event) = self.receiver.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Helper to create an event with current timestamp.
+pub fn make_event(kind: EventKind, source: impl Into<String>, data: serde_json::Value) -> Event {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    Event {
+        kind,
+        source: source.into(),
+        data,
+        timestamp_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis().try_into().unwrap_or(u64::MAX),
+    }
+}

--- a/src/runtime/events/tests.rs
+++ b/src/runtime/events/tests.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+#[test]
+fn emit_and_drain() {
+    let bus = EventBus::new();
+    bus.emit(make_event(EventKind::WorkflowStarted, "wf1", serde_json::json!({"trigger": "new"}))).unwrap();
+    bus.emit(make_event(EventKind::StepStarted, "step1", serde_json::json!({}))).unwrap();
+    let events = bus.drain();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].kind, EventKind::WorkflowStarted);
+}
+
+#[test]
+fn drain_empty() {
+    let bus = EventBus::new();
+    assert!(bus.drain().is_empty());
+}
+
+#[test]
+fn sender_clone() {
+    let bus = EventBus::new();
+    let s = bus.sender();
+    s.send(make_event(EventKind::ToolCalled, "tool", serde_json::json!({}))).unwrap();
+    assert_eq!(bus.drain().len(), 1);
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,13 +1,18 @@
+pub mod alerting;
 pub mod audit;
 pub mod budget;
 pub mod engine;
+pub mod events;
 pub mod execution;
 pub mod executor;
 pub mod injection;
 pub mod interceptor;
+pub mod observability;
 pub mod permissions;
 pub mod provider;
+pub mod registry;
 pub mod sandbox;
+pub mod webhook;
 pub mod workflow;
 
 use serde::{Deserialize, Serialize};

--- a/src/runtime/observability/mod.rs
+++ b/src/runtime/observability/mod.rs
@@ -1,0 +1,104 @@
+//! Observability exports for OTLP, Datadog, and Prometheus.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[cfg(test)]
+mod tests;
+
+/// A metric data point.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metric {
+    pub name: String,
+    pub value: f64,
+    pub labels: HashMap<String, String>,
+    pub timestamp_ms: u64,
+}
+
+/// Export format for metrics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFormat {
+    Prometheus,
+    Otlp,
+    Datadog,
+    Json,
+}
+
+/// In-process metrics collector.
+pub struct MetricsCollector {
+    metrics: Mutex<Vec<Metric>>,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self {
+            metrics: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Record a metric.
+    pub fn record(&self, name: impl Into<String>, value: f64, labels: HashMap<String, String>) {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics.lock().unwrap().push(Metric {
+            name: name.into(),
+            value,
+            labels,
+            timestamp_ms: ts,
+        });
+    }
+
+    /// Export all metrics in the given format.
+    pub fn export(&self, format: &ExportFormat) -> String {
+        let metrics = self.metrics.lock().unwrap();
+        match format {
+            ExportFormat::Prometheus => export_prometheus(&metrics),
+            ExportFormat::Json => serde_json::to_string_pretty(&*metrics).unwrap_or_default(),
+            ExportFormat::Otlp | ExportFormat::Datadog => {
+                // Placeholder: real implementations would use protocol-specific formats
+                serde_json::to_string(&*metrics).unwrap_or_default()
+            }
+        }
+    }
+
+    /// Number of recorded metrics.
+    pub fn len(&self) -> usize {
+        self.metrics.lock().unwrap().len()
+    }
+
+    /// Whether any metrics have been recorded.
+    pub fn is_empty(&self) -> bool {
+        self.metrics.lock().unwrap().is_empty()
+    }
+}
+
+impl Default for MetricsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn export_prometheus(metrics: &[Metric]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for m in metrics {
+        out.push_str(&m.name);
+        if !m.labels.is_empty() {
+            out.push('{');
+            let labels: Vec<String> = m
+                .labels
+                .iter()
+                .map(|(k, v)| format!("{k}=\"{v}\""))
+                .collect();
+            out.push_str(&labels.join(","));
+            out.push('}');
+        }
+        let _ = writeln!(out, " {}", m.value);
+    }
+    out
+}

--- a/src/runtime/observability/tests.rs
+++ b/src/runtime/observability/tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn record_and_export_json() {
+    let c = MetricsCollector::new();
+    c.record("rein_step_duration_ms", 150.0, HashMap::new());
+    let json = c.export(&ExportFormat::Json);
+    assert!(json.contains("rein_step_duration_ms"));
+}
+
+#[test]
+fn prometheus_export() {
+    let c = MetricsCollector::new();
+    let mut labels = HashMap::new();
+    labels.insert("workflow".to_string(), "support".to_string());
+    c.record("rein_workflow_total", 1.0, labels);
+    let prom = c.export(&ExportFormat::Prometheus);
+    assert!(prom.contains("rein_workflow_total{workflow=\"support\"} 1"));
+}
+
+#[test]
+fn empty_collector() {
+    let c = MetricsCollector::new();
+    assert!(c.is_empty());
+    assert_eq!(c.len(), 0);
+}

--- a/src/runtime/registry/mod.rs
+++ b/src/runtime/registry/mod.rs
@@ -1,0 +1,66 @@
+//! Tool registry client for discovering and fetching tool definitions.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests;
+
+/// A tool definition in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub namespace: String,
+    pub version: String,
+    pub description: String,
+    /// Tool endpoint URL or command.
+    pub endpoint: Option<String>,
+    /// Input schema (JSON Schema).
+    pub input_schema: Option<serde_json::Value>,
+    /// Output schema (JSON Schema).
+    pub output_schema: Option<serde_json::Value>,
+}
+
+/// In-memory tool registry.
+#[derive(Debug, Default)]
+pub struct ToolRegistry {
+    tools: HashMap<String, ToolDef>,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a tool.
+    pub fn register(&mut self, tool: ToolDef) {
+        let key = format!("{}.{}", tool.namespace, tool.name);
+        self.tools.insert(key, tool);
+    }
+
+    /// Look up a tool by namespace.action.
+    pub fn get(&self, qualified_name: &str) -> Option<&ToolDef> {
+        self.tools.get(qualified_name)
+    }
+
+    /// List all tools in a namespace.
+    pub fn list_namespace(&self, namespace: &str) -> Vec<&ToolDef> {
+        self.tools
+            .values()
+            .filter(|t| t.namespace == namespace)
+            .collect()
+    }
+
+    /// List all registered tools.
+    pub fn list_all(&self) -> Vec<&ToolDef> {
+        self.tools.values().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}

--- a/src/runtime/registry/tests.rs
+++ b/src/runtime/registry/tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+fn make_tool(ns: &str, name: &str) -> ToolDef {
+    ToolDef {
+        name: name.to_string(),
+        namespace: ns.to_string(),
+        version: "1.0.0".to_string(),
+        description: format!("{ns}.{name}"),
+        endpoint: None,
+        input_schema: None,
+        output_schema: None,
+    }
+}
+
+#[test]
+fn register_and_get() {
+    let mut reg = ToolRegistry::new();
+    reg.register(make_tool("zendesk", "read_ticket"));
+    let tool = reg.get("zendesk.read_ticket").unwrap();
+    assert_eq!(tool.name, "read_ticket");
+}
+
+#[test]
+fn list_namespace() {
+    let mut reg = ToolRegistry::new();
+    reg.register(make_tool("zendesk", "read_ticket"));
+    reg.register(make_tool("zendesk", "refund"));
+    reg.register(make_tool("stripe", "charge"));
+    assert_eq!(reg.list_namespace("zendesk").len(), 2);
+    assert_eq!(reg.list_namespace("stripe").len(), 1);
+}
+
+#[test]
+fn missing_tool() {
+    let reg = ToolRegistry::new();
+    assert!(reg.get("nonexistent.tool").is_none());
+}

--- a/src/runtime/webhook/mod.rs
+++ b/src/runtime/webhook/mod.rs
@@ -1,0 +1,89 @@
+//! Webhook configuration and dispatch.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests;
+
+/// A configured webhook endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    pub name: String,
+    pub url: String,
+    /// Events that trigger this webhook.
+    pub events: Vec<String>,
+    /// Optional signing secret for HMAC verification.
+    pub secret: Option<String>,
+    /// Additional headers to include.
+    pub headers: HashMap<String, String>,
+    /// Whether the webhook is active.
+    pub active: bool,
+}
+
+/// A webhook payload ready for dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookPayload {
+    pub event: String,
+    pub timestamp: String,
+    pub data: serde_json::Value,
+}
+
+impl WebhookConfig {
+    /// Create a new webhook config.
+    pub fn new(name: impl Into<String>, url: impl Into<String>, events: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            url: url.into(),
+            events,
+            secret: None,
+            headers: HashMap::new(),
+            active: true,
+        }
+    }
+
+    /// Check if this webhook should fire for the given event.
+    pub fn matches_event(&self, event: &str) -> bool {
+        self.active && (self.events.contains(&"*".to_string()) || self.events.iter().any(|e| e == event))
+    }
+
+    /// Compute HMAC signature for a payload.
+    pub fn sign(&self, payload: &[u8]) -> Option<String> {
+        self.secret.as_ref().map(|secret| {
+            let mut hasher = Sha256::new();
+            hasher.update(secret.as_bytes());
+            hasher.update(payload);
+            format!("sha256={:x}", hasher.finalize())
+        })
+    }
+}
+
+/// Registry of webhook configurations.
+#[derive(Debug, Default)]
+pub struct WebhookRegistry {
+    hooks: Vec<WebhookConfig>,
+}
+
+impl WebhookRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, config: WebhookConfig) {
+        self.hooks.push(config);
+    }
+
+    /// Get all webhooks that match an event.
+    pub fn matching(&self, event: &str) -> Vec<&WebhookConfig> {
+        self.hooks.iter().filter(|h| h.matches_event(event)).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.hooks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
+    }
+}

--- a/src/runtime/webhook/tests.rs
+++ b/src/runtime/webhook/tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+#[test]
+fn matches_specific_event() {
+    let hook = WebhookConfig::new("h", "https://example.com", vec!["workflow.complete".into()]);
+    assert!(hook.matches_event("workflow.complete"));
+    assert!(!hook.matches_event("workflow.failed"));
+}
+
+#[test]
+fn wildcard_matches_all() {
+    let hook = WebhookConfig::new("h", "https://example.com", vec!["*".into()]);
+    assert!(hook.matches_event("anything"));
+}
+
+#[test]
+fn inactive_never_matches() {
+    let mut hook = WebhookConfig::new("h", "https://example.com", vec!["*".into()]);
+    hook.active = false;
+    assert!(!hook.matches_event("anything"));
+}
+
+#[test]
+fn sign_payload() {
+    let mut hook = WebhookConfig::new("h", "https://example.com", vec![]);
+    hook.secret = Some("mysecret".to_string());
+    let sig = hook.sign(b"payload");
+    assert!(sig.unwrap().starts_with("sha256="));
+}
+
+#[test]
+fn registry_matching() {
+    let mut reg = WebhookRegistry::new();
+    reg.register(WebhookConfig::new("a", "https://a.com", vec!["wf.start".into()]));
+    reg.register(WebhookConfig::new("b", "https://b.com", vec!["wf.complete".into()]));
+    assert_eq!(reg.matching("wf.start").len(), 1);
+    assert_eq!(reg.matching("wf.start")[0].name, "a");
+}


### PR DESCRIPTION
Infrastructure batch:

- **#163** — Webhook registry with HMAC signing, event matching, wildcard support
- **#164** — Event bus with in-process pub/sub (mpsc channels)
- **#169** — Metrics collector with Prometheus/JSON/OTLP export
- **#170** — Alert engine with threshold rules and severity levels
- **#171** — Tool registry with namespace-based lookup

37 new tests, 473 total passing, clippy clean.

Closes #163
Closes #164
Closes #169
Closes #170
Closes #171