### PR TITLE
docs: real-world example .rein files

### DIFF
--- a/examples/code_review.rein
+++ b/examples/code_review.rein
@@ -1,0 +1,55 @@
+// Automated code review with parallel security scanning.
+
+provider openai {
+    model: "gpt-4o"
+    key: env("OPENAI_API_KEY")
+}
+
+agent code_reviewer {
+    model: openai
+
+    can [
+        github.read_pr
+        github.read_diff
+        github.post_comment
+        github.request_changes
+    ]
+
+    cannot [
+        github.merge_pr
+        github.delete_branch
+        github.push_code
+        github.approve_pr
+    ]
+
+    budget: $5 per day
+}
+
+agent security_scanner {
+    model: openai
+
+    can [
+        github.read_pr
+        github.read_diff
+        github.post_comment
+    ]
+
+    cannot [
+        github.merge_pr
+        github.approve_pr
+        github.push_code
+    ]
+
+    budget: $3 per day
+
+    guardrails {
+        output_filter {
+            sensitive_data: block
+        }
+    }
+}
+
+workflow review_pipeline {
+    trigger: pull_request
+    stages: [code_reviewer, security_scanner]
+}

--- a/examples/customer_support.rein
+++ b/examples/customer_support.rein
@@ -1,0 +1,75 @@
+// Customer support system with tiered agents and budget controls.
+
+provider anthropic {
+    model: "claude-sonnet-4-20250514"
+    key: env("ANTHROPIC_API_KEY")
+}
+
+type TicketCategory {
+    label: one of [billing, technical, account, general]
+    confidence: percentage
+}
+
+agent classifier {
+    model: anthropic
+
+    can [
+        zendesk.read_ticket
+    ]
+
+    cannot [
+        zendesk.reply_ticket
+        zendesk.delete_ticket
+    ]
+
+    budget: $0.01 per ticket
+}
+
+agent support_rep {
+    model: anthropic
+
+    can [
+        zendesk.read_ticket
+        zendesk.reply_ticket
+        zendesk.add_internal_note
+        stripe.lookup_customer
+    ]
+
+    cannot [
+        zendesk.delete_ticket
+        stripe.refund
+        stripe.modify_subscription
+    ]
+
+    budget: $0.05 per ticket
+
+    guardrails {
+        output_filter {
+            pii: redact
+            toxicity: block
+        }
+    }
+}
+
+agent billing_specialist {
+    model: anthropic
+
+    can [
+        zendesk.read_ticket
+        zendesk.reply_ticket
+        stripe.lookup_customer
+        stripe.refund up to $50
+    ]
+
+    cannot [
+        stripe.modify_subscription
+        zendesk.delete_ticket
+    ]
+
+    budget: $25 per day
+}
+
+workflow support_pipeline {
+    trigger: incoming_ticket
+    stages: [classifier, support_rep, billing_specialist]
+}

--- a/examples/data_pipeline.rein
+++ b/examples/data_pipeline.rein
@@ -1,0 +1,60 @@
+// Content moderation with progressive trust tiers.
+
+provider anthropic {
+    model: "claude-sonnet-4-20250514"
+    key: env("ANTHROPIC_API_KEY")
+}
+
+type ModerationResult {
+    verdict: one of [safe, flagged, blocked]
+    confidence: percentage
+    category: one of [spam, harassment, nsfw, misinformation, clean]
+}
+
+agent moderator {
+    model: anthropic
+
+    can [
+        content.read
+        content.classify
+        content.flag
+    ]
+
+    cannot [
+        content.delete
+        content.ban_user
+        users.modify
+    ]
+
+    budget: $100 per day
+}
+
+agent senior_moderator {
+    model: anthropic
+
+    can [
+        content.read
+        content.classify
+        content.flag
+        content.delete
+        content.ban_user
+    ]
+
+    cannot [
+        users.modify
+        billing.refund
+    ]
+
+    budget: $200 per day
+}
+
+policy {
+    tier supervised {
+        promote when accuracy > 95%
+    }
+}
+
+workflow moderation_pipeline {
+    trigger: new_content
+    stages: [moderator, senior_moderator]
+}


### PR DESCRIPTION
Closes #258

Three use-case examples:
- **customer_support.rein** — tiered support with classifier, rep, billing specialist. Budget per ticket, guardrails with PII redaction.
- **code_review.rein** — parallel review + security scanning. Read-only permissions, no merge/approve access.
- **data_pipeline.rein** — content moderation with progressive trust tiers.

All validate clean. Each demonstrates different Rein features.