### PR TITLE
fix: QA bugs batch — equality operators, unwrap hygiene, rein serve, unused import

### DIFF
--- a/src/ast/workflow.rs
+++ b/src/ast/workflow.rs
@@ -80,6 +80,8 @@ pub enum CompareOp {
     Gt,
     LtEq,
     GtEq,
+    Eq,
+    NotEq,
 }
 
 /// A value in a `when` comparison (right-hand side).
@@ -92,6 +94,8 @@ pub enum WhenValue {
     Currency { symbol: char, amount: u64 },
     /// A plain number.
     Number(String),
+    /// A string literal like `"critical"`.
+    String(String),
     /// An identifier reference.
     Ident(String),
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod explain;
 pub mod fmt;
 pub mod init;
 pub mod run;
+pub mod serve;
 pub mod validate;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,0 +1,48 @@
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+
+use rein::parser::parse;
+use rein::server::{AppState, serve};
+
+/// Run the Rein API server.
+pub fn run_serve(file: &Path, host: &str, port: u16) -> i32 {
+    let source = match std::fs::read_to_string(file) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not read {}: {e}", file.display());
+            return 1;
+        }
+    };
+
+    let rein_file = match parse(&source) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("parse error: {e}");
+            return 1;
+        }
+    };
+
+    let state = Arc::new(AppState {
+        rein_file,
+        audit_log: None,
+    });
+
+    let addr: SocketAddr = match format!("{host}:{port}").parse() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: invalid address {host}:{port}: {e}");
+            return 1;
+        }
+    };
+
+    eprintln!("rein serve listening on http://{addr}");
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    if let Err(e) = rt.block_on(serve(state, addr)) {
+        eprintln!("server error: {e}");
+        return 1;
+    }
+
+    0
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -91,6 +91,8 @@ pub enum TokenKind {
     Gt,
     LtEq,
     GtEq,
+    EqEq,
+    BangEq,
     Percent,
     // Symbols
     LBrace,
@@ -156,6 +158,7 @@ impl TokenKind {
             Self::Or => "or", Self::And => "and",
             Self::Lt => "<", Self::Gt => ">",
             Self::LtEq => "<=", Self::GtEq => ">=",
+            Self::EqEq => "==", Self::BangEq => "!=",
             Self::Percent => "%", Self::Arrow => "->",
             Self::Route => "route", Self::On => "on",
             Self::Underscore => "_", Self::DotDot => "..",

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -71,7 +71,7 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
         let end = self.pos;
-        let word = std::str::from_utf8(&self.src[start..end]).unwrap();
+        let word = std::str::from_utf8(&self.src[start..end]).expect("input should be valid UTF-8");
         // "key" is context-sensitive; lexed as Ident, matched in parser
         let kind = if word == "key" {
             TokenKind::Ident("key".to_string())
@@ -93,7 +93,7 @@ impl<'a> Lexer<'a> {
             }
         }
         let end = self.pos;
-        let text = std::str::from_utf8(&self.src[start..end]).unwrap().to_string();
+        let text = std::str::from_utf8(&self.src[start..end]).expect("input should be valid UTF-8").to_string();
         Token::new(TokenKind::Number(text), start, end)
     }
 
@@ -161,7 +161,7 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).unwrap();
+        let num_str = std::str::from_utf8(&self.src[num_start..self.pos]).expect("numeric literal should be valid UTF-8");
         let cents = parse_cents(num_str).map_err(|()| LexError {
             message: format!("invalid currency amount: '{symbol}{num_str}'"),
             span: Span::new(start, self.pos),
@@ -224,6 +224,19 @@ impl<'a> Lexer<'a> {
         Ok(Token::new(TokenKind::Comment, start, self.pos))
     }
 
+    /// Lex a comparison or equality operator starting with `<`, `>`, `=`, or `!`.
+    fn read_comparison(&mut self, ch: u8, start: usize) -> Option<Token> {
+        match ch {
+            b'<' if self.peek() == Some(b'=') => { self.advance(); Some(Token::new(TokenKind::LtEq, start, self.pos)) }
+            b'<' => Some(Token::new(TokenKind::Lt, start, self.pos)),
+            b'>' if self.peek() == Some(b'=') => { self.advance(); Some(Token::new(TokenKind::GtEq, start, self.pos)) }
+            b'>' => Some(Token::new(TokenKind::Gt, start, self.pos)),
+            b'=' if self.peek() == Some(b'=') => { self.advance(); Some(Token::new(TokenKind::EqEq, start, self.pos)) }
+            b'!' if self.peek() == Some(b'=') => { self.advance(); Some(Token::new(TokenKind::BangEq, start, self.pos)) }
+            _ => None,
+        }
+    }
+
     fn run(&mut self) -> Result<Vec<Token>, LexError> {
         let mut tokens = Vec::new();
         loop {
@@ -269,20 +282,14 @@ impl<'a> Lexer<'a> {
                     self.advance(); // consume '>'
                     tokens.push(Token::new(TokenKind::Arrow, start, self.pos));
                 }
-                Some(b'<') => {
-                    if self.peek() == Some(b'=') {
-                        self.advance();
-                        tokens.push(Token::new(TokenKind::LtEq, start, self.pos));
+                Some(ch @ (b'<' | b'>' | b'=' | b'!')) => {
+                    if let Some(tok) = self.read_comparison(ch, start) {
+                        tokens.push(tok);
                     } else {
-                        tokens.push(Token::new(TokenKind::Lt, start, self.pos));
-                    }
-                }
-                Some(b'>') => {
-                    if self.peek() == Some(b'=') {
-                        self.advance();
-                        tokens.push(Token::new(TokenKind::GtEq, start, self.pos));
-                    } else {
-                        tokens.push(Token::new(TokenKind::Gt, start, self.pos));
+                        return Err(LexError {
+                            message: format!("unexpected character: '{}'", ch as char),
+                            span: Span::new(start, self.pos),
+                        });
                     }
                 }
                 Some(b'%') => tokens.push(Token::new(TokenKind::Percent, start, self.pos)),

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -535,3 +535,14 @@ fn tool_and_endpoint_keywords() {
     assert_eq!(tokens[3].kind, TokenKind::Endpoint);
     assert_eq!(tokens[4].kind, TokenKind::Colon);
 }
+
+#[test]
+fn equality_operators() {
+    let src = "a == b != c";
+    let tokens = non_eof(lex_ok(src));
+    assert_eq!(tokens[0].kind, TokenKind::Ident("a".into()));
+    assert_eq!(tokens[1].kind, TokenKind::EqEq);
+    assert_eq!(tokens[2].kind, TokenKind::Ident("b".into()));
+    assert_eq!(tokens[3].kind, TokenKind::BangEq);
+    assert_eq!(tokens[4].kind, TokenKind::Ident("c".into()));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,17 @@ enum Command {
         /// Path to the .rein file
         file: std::path::PathBuf,
     },
+    /// Start the Rein API server
+    Serve {
+        /// Path to the .rein file to serve
+        file: std::path::PathBuf,
+        /// Host to bind to
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+        /// Port to listen on
+        #[arg(short, long, default_value_t = 3000)]
+        port: u16,
+    },
     /// Run an agent defined in a .rein file
     Run {
         /// Path to the .rein file
@@ -90,6 +101,10 @@ async fn main() {
         }
         Command::Explain { file } => {
             let exit_code = commands::explain::run_explain(&file);
+            process::exit(exit_code);
+        }
+        Command::Serve { file, host, port } => {
+            let exit_code = commands::serve::run_serve(&file, &host, port);
             process::exit(exit_code);
         }
         Command::Run { file, message } => {

--- a/src/parser/condition_parser.rs
+++ b/src/parser/condition_parser.rs
@@ -106,7 +106,7 @@ impl Parser {
         }
 
         if parts.len() == 1 {
-            Ok(parts.into_iter().next().unwrap())
+            Ok(parts.into_iter().next().expect("parts vec must have at least one element"))
         } else {
             Ok(WhenExpr::Or(parts))
         }
@@ -128,7 +128,7 @@ impl Parser {
         }
 
         if parts.len() == 1 {
-            Ok(parts.into_iter().next().unwrap())
+            Ok(parts.into_iter().next().expect("parts vec must have at least one element"))
         } else {
             Ok(WhenExpr::And(parts))
         }
@@ -143,9 +143,11 @@ impl Parser {
             TokenKind::Gt => CompareOp::Gt,
             TokenKind::LtEq => CompareOp::LtEq,
             TokenKind::GtEq => CompareOp::GtEq,
+            TokenKind::EqEq => CompareOp::Eq,
+            TokenKind::BangEq => CompareOp::NotEq,
             other => {
                 return Err(ParseError::new(
-                    format!("expected comparison operator (<, >, <=, >=), got {other}"),
+                    format!("expected comparison operator (<, >, <=, >=, ==, !=), got {other}"),
                     self.current_span(),
                 ));
             }
@@ -174,6 +176,11 @@ impl Parser {
             TokenKind::Currency { symbol, amount } => {
                 self.advance();
                 Ok(WhenValue::Currency { symbol, amount })
+            }
+            TokenKind::StringLiteral(s) => {
+                let s = s.clone();
+                self.advance();
+                Ok(WhenValue::String(s))
             }
             TokenKind::Ident(name) => {
                 let name = name.clone();

--- a/src/parser/eval_parser.rs
+++ b/src/parser/eval_parser.rs
@@ -136,6 +136,8 @@ impl Parser {
             TokenKind::Lt => CompareOp::Lt,
             TokenKind::GtEq => CompareOp::GtEq,
             TokenKind::LtEq => CompareOp::LtEq,
+            TokenKind::EqEq => CompareOp::Eq,
+            TokenKind::BangEq => CompareOp::NotEq,
             other => {
                 return Err(ParseError::new(
                     format!("expected comparison operator in assert, got {other}"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -204,7 +204,7 @@ impl Parser {
             }
             // Keywords that can appear as values in certain contexts
             kind if kind.keyword_as_ident().is_some() => {
-                let name = kind.keyword_as_ident().unwrap().to_string();
+                let name = kind.keyword_as_ident().expect("guarded by is_some check").to_string();
                 self.advance();
                 Ok(ValueExpr::Literal(name))
             }

--- a/src/parser/pipe_parser.rs
+++ b/src/parser/pipe_parser.rs
@@ -52,6 +52,8 @@ impl Parser {
             TokenKind::Gt => CompareOp::Gt,
             TokenKind::LtEq => CompareOp::LtEq,
             TokenKind::GtEq => CompareOp::GtEq,
+            TokenKind::EqEq => CompareOp::Eq,
+            TokenKind::BangEq => CompareOp::NotEq,
             other => {
                 return Err(ParseError::new(
                     format!("expected comparison operator in where clause, got {other}"),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1560,6 +1560,58 @@ fn parse_step_without_when() {
     assert!(f.workflows[0].steps[0].when.is_none());
 }
 
+#[test]
+fn parse_step_with_when_equality() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: status == "critical"
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Comparison(c) => {
+            assert_eq!(c.field, "status");
+            assert_eq!(c.op, crate::ast::CompareOp::Eq);
+            assert!(matches!(&c.value, crate::ast::WhenValue::String(s) if s == "critical"));
+        }
+        other => panic!("expected Comparison, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_step_with_when_not_equal() {
+    let f = parse_ok(
+        r#"
+        agent a { model: openai }
+        workflow w {
+            trigger: event
+            step x {
+                agent: a
+                when: tier != "free"
+            }
+        }
+    "#,
+    );
+    let step = &f.workflows[0].steps[0];
+    let when = step.when.as_ref().unwrap();
+    match when {
+        crate::ast::WhenExpr::Comparison(c) => {
+            assert_eq!(c.field, "tier");
+            assert_eq!(c.op, crate::ast::CompareOp::NotEq);
+            assert!(matches!(&c.value, crate::ast::WhenValue::String(s) if s == "free"));
+        }
+        other => panic!("expected Comparison, got {other:?}"),
+    }
+}
+
 // ── retry policy tests ──────────────────────────────────────────────────
 
 #[test]

--- a/src/parser/workflow_parser.rs
+++ b/src/parser/workflow_parser.rs
@@ -229,6 +229,8 @@ impl Parser {
                 TokenKind::Gt => CompareOp::Gt,
                 TokenKind::LtEq => CompareOp::LtEq,
                 TokenKind::GtEq => CompareOp::GtEq,
+                TokenKind::EqEq => CompareOp::Eq,
+                TokenKind::BangEq => CompareOp::NotEq,
                 other => {
                     return Err(ParseError::new(
                         format!("expected comparison operator or 'is', got {other}"),

--- a/src/runtime/observability/mod.rs
+++ b/src/runtime/observability/mod.rs
@@ -45,7 +45,7 @@ impl MetricsCollector {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics.lock().unwrap().push(Metric {
+        self.metrics.lock().expect("metrics mutex poisoned").push(Metric {
             name: name.into(),
             value,
             labels,
@@ -55,7 +55,7 @@ impl MetricsCollector {
 
     /// Export all metrics in the given format.
     pub fn export(&self, format: &ExportFormat) -> String {
-        let metrics = self.metrics.lock().unwrap();
+        let metrics = self.metrics.lock().expect("metrics mutex poisoned");
         match format {
             ExportFormat::Prometheus => export_prometheus(&metrics),
             ExportFormat::Json => serde_json::to_string_pretty(&*metrics).unwrap_or_default(),
@@ -68,12 +68,12 @@ impl MetricsCollector {
 
     /// Number of recorded metrics.
     pub fn len(&self) -> usize {
-        self.metrics.lock().unwrap().len()
+        self.metrics.lock().expect("metrics mutex poisoned").len()
     }
 
     /// Whether any metrics have been recorded.
     pub fn is_empty(&self) -> bool {
-        self.metrics.lock().unwrap().is_empty()
+        self.metrics.lock().expect("metrics mutex poisoned").is_empty()
     }
 }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3,7 +3,6 @@ use axum::http::{Request, StatusCode};
 use std::sync::Arc;
 use tower::ServiceExt;
 
-use crate::ast::ReinFile;
 use crate::parser::parse;
 
 use super::{AppState, build_router};


### PR DESCRIPTION
## Changes

### #240 — == and != operators
- Added `EqEq` and `BangEq` tokens to lexer
- Added `Eq` and `NotEq` variants to `CompareOp` enum
- Added `WhenValue::String` variant for string literal comparisons
- Updated all 4 parser files (condition, eval, workflow, pipe) to handle new operators
- 3 new tests (lexer + parser)

### #241 — unwrap() hygiene
- Replaced all production `unwrap()` calls with descriptive `expect()` messages
- Lexer (UTF-8 parsing), observability (mutex locks), parser (vec access, keyword conversion)

### #242 — rein serve command
- Added `rein serve` CLI subcommand to start the REST API server
- Wires up the existing axum server code that was previously inaccessible
- Supports `--host` (default 127.0.0.1) and `--port` (default 3000) flags

### #243 — unused import
- Removed unused `crate::ast::ReinFile` import in server/tests.rs

## Testing
- 517 tests passing (up from 514)
- Zero clippy warnings
- All existing tests unaffected

Closes #240, #241, #242, #243