### PR TITLE
ci: add CI, release, and reusable validation workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-targets
+      - run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          name="rein-${tag}-${{ matrix.target }}"
+          mkdir -p "$name"
+          cp "target/${{ matrix.target }}/release/rein" "$name/"
+          cp README.md LICENSE* "$name/" 2>/dev/null || true
+          tar czf "${name}.tar.gz" "$name"
+          echo "ASSET=${name}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/**/*.tar.gz

--- a/.github/workflows/validate-action.yml
+++ b/.github/workflows/validate-action.yml
@@ -1,0 +1,59 @@
+name: Rein Validate (Reusable)
+
+# This workflow can be called from other repos to validate .rein files.
+# Usage in another repo:
+#
+#   jobs:
+#     validate:
+#       uses: delamain-labs/rein/.github/workflows/validate-action.yml@master
+#       with:
+#         files: 'policies/*.rein'
+#         strict: true
+
+on:
+  workflow_call:
+    inputs:
+      files:
+        description: 'Glob pattern for .rein files to validate'
+        required: true
+        type: string
+      strict:
+        description: 'Enable strict mode (warn on unenforced features)'
+        required: false
+        type: boolean
+        default: false
+      check-fmt:
+        description: 'Check formatting'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install rein
+        run: cargo install --git https://github.com/delamain-labs/rein.git
+
+      - name: Validate
+        run: |
+          flags=""
+          if [ "${{ inputs.strict }}" = "true" ]; then
+            flags="--strict"
+          fi
+          for f in ${{ inputs.files }}; do
+            echo "Validating $f..."
+            rein validate $flags "$f"
+          done
+
+      - name: Check formatting
+        if: inputs.check-fmt
+        run: |
+          for f in ${{ inputs.files }}; do
+            rein fmt --check "$f"
+          done


### PR DESCRIPTION
## Changes

### CI Workflow (.github/workflows/ci.yml)
- Runs on push to master and PRs
- cargo test + clippy + fmt check

### Release Workflow (.github/workflows/release.yml)
- Triggered on version tags (v*)
- Builds prebuilt binaries for 4 targets:
  - x86_64-unknown-linux-gnu
  - aarch64-unknown-linux-gnu
  - x86_64-apple-darwin
  - aarch64-apple-darwin
- Packages as tar.gz with README and LICENSE
- Creates GitHub Release with auto-generated notes

### Reusable Validation Action (.github/workflows/validate-action.yml)
- Callable from other repos via `workflow_call`
- Supports file glob, strict mode, and format checking
- Documents usage in the file itself

## Usage

To create a release:
```bash
git tag v0.1.0
git push origin v0.1.0
```

Closes #253, #254