### PR TITLE
feat(dx): AI assistant skill files for Claude, Cursor, Copilot

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,38 @@
+# Rein Language Rules
+
+You are working with Rein, a declarative language for AI agent governance.
+
+## File Format
+- Extension: `.rein`
+- Encoding: UTF-8
+- Comments: `//`, `#`, `/* */`
+
+## Key Block Types
+- `agent name { model: x, can: [...], cannot: [...], budget: $N per day }`
+- `workflow name { trigger: event, step name { agent: x, goal: "..." } }`
+- `provider name { model: x, key: env("KEY") }`
+- `defaults { model: x, budget: $N per day }`
+- `type Name { field: type }`
+- `policy name { tier name { can: [...], when: condition } }`
+
+## Important Rules
+- Every agent needs a `model` field
+- `can` and `cannot` are capability lists (comma-separated or bracket-enclosed)
+- Budget syntax: `$100 per day`, `€50 per month`, `£25 per hour`
+- `when` conditions: `field op value` with `and`/`or` logic
+- Operators: `<`, `>`, `<=`, `>=`, `==`, `!=`
+- `env("VAR")` or `env("VAR", "default")` for environment variables
+- `up_to` constrains capabilities: `can: refund up_to $500`
+
+## CLI Commands
+- `rein validate <file>` — parse and validate
+- `rein validate --strict <file>` — warn on unenforced features
+- `rein fmt <file>` — auto-format
+- `rein explain <file>` — human-readable summary
+- `rein run --dry-run <file>` — execution plan without API calls
+- `rein init <name>` — scaffold a project
+
+## Testing
+- `cargo test` — run all tests
+- `cargo clippy -- -D warnings` — lint check
+- Tests live in separate `tests.rs` files alongside `mod.rs`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Rein — Copilot Instructions
+
+Rein is a declarative DSL for AI agent governance (`.rein` files).
+
+## Syntax Basics
+- Blocks: `agent name { ... }`, `workflow name { ... }`
+- Fields: `key: value` (colon-separated)
+- Lists: `can: action1, action2` or `can [ action1 \n action2 ]`
+- Comments: `//`, `#`, `/* */`
+- Budget: `$100 per day`, `€50 per month`
+- Env refs: `env("KEY")`, `env("KEY", "default")`
+- Conditions: `when: field > value and field < value`
+
+## Project Conventions
+- Rust, edition 2024
+- Tests in `tests.rs` files (not inline `#[cfg(test)]`)
+- clippy pedantic: `cargo clippy -- -D warnings`
+- No file over 400 lines
+- Squash-merge PRs to master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — Rein Project Context
+
+Rein is a declarative language and runtime for AI agent orchestration. Think "Terraform for AI agents."
+
+## Project Structure
+```
+src/
+  ast/         — AST types (25+ block types)
+  lexer/       — Tokenizer (scanner.rs, mod.rs, tests.rs)
+  parser/      — Recursive descent parser (mod.rs + specialized parsers)
+  validator/   — Semantic validation + strict mode
+  runtime/     — Agent execution, workflows, tracing
+  commands/    — CLI commands (validate, fmt, run, serve, etc.)
+  server/      — REST API (axum)
+  main.rs      — CLI entry point (clap)
+examples/      — Example .rein files
+docs/          — Language reference, spec, getting started
+```
+
+## Key Conventions
+- **TDD always.** Tests in separate `tests.rs` files alongside `mod.rs`.
+- **No file over ~400 lines.** Split when approaching.
+- **clippy pedantic.** `cargo clippy -- -D warnings` must pass.
+- **Branch per task.** PR, squash-merge to master. Never stack PRs.
+- **Commit format:** `feat(scope): description. Closes #XX`
+
+## The Language
+- `.rein` files define agents, workflows, policies, and governance
+- 25+ block types, full parser support
+- Runtime only executes basic agent runs + sequential workflows
+- Most features are parse-only (use `--strict` to see which)
+
+## CLI
+```
+rein validate [--ast] [--strict] [--format json] <file>
+rein fmt [--check] <files>
+rein init [name]
+rein explain <file>
+rein cost <paths>
+rein run [--dry-run] [-m "msg"] <file>
+rein serve [--host H] [--port P] <file>
+```
+
+## Testing
+```bash
+cargo test                      # 517 tests
+cargo clippy -- -D warnings     # zero warnings
+cargo test -- --test-threads=1  # if tests conflict
+```
+
+## What's Enforced at Runtime
+- Agent model, can/cannot lists, basic budget tracking
+- Sequential workflow step execution
+- Tool permission enforcement (default-deny)
+- Everything else parses but doesn't execute (yet)


### PR DESCRIPTION
Adds context files for AI coding assistants:

- **CLAUDE.md** — Claude Code / Claude context file with project structure, conventions, CLI reference
- **.cursorrules** — Cursor rules file with .rein syntax guide
- **.github/copilot-instructions.md** — GitHub Copilot instructions

These teach AI assistants about Rein's syntax, project conventions, and CLI commands so they can contribute effectively.

Closes #102