### PR TITLE
feat(runtime): schedule evaluator, eval assertions, memory store

### DIFF
--- a/src/runtime/eval/mod.rs
+++ b/src/runtime/eval/mod.rs
@@ -1,0 +1,78 @@
+//! Eval block runtime: runs assertions against datasets.
+
+use crate::ast::{CompareOp, EvalAssertion, EvalDef};
+
+#[cfg(test)]
+mod tests;
+
+/// Result of evaluating a single assertion.
+#[derive(Debug, Clone)]
+pub struct AssertionResult {
+    pub metric: String,
+    pub expected: String,
+    pub actual: f64,
+    pub passed: bool,
+}
+
+/// Result of evaluating an entire eval block.
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+    pub name: Option<String>,
+    pub dataset: String,
+    pub assertions: Vec<AssertionResult>,
+    pub passed: bool,
+}
+
+/// Evaluate a single assertion against a metric value.
+#[must_use]
+pub fn check_assertion(assertion: &EvalAssertion, actual: f64) -> AssertionResult {
+    let threshold = parse_threshold(&assertion.value);
+    let passed = match assertion.op {
+        CompareOp::Lt => actual < threshold,
+        CompareOp::Gt => actual > threshold,
+        CompareOp::LtEq => actual <= threshold,
+        CompareOp::GtEq => actual >= threshold,
+        CompareOp::Eq => (actual - threshold).abs() < f64::EPSILON,
+        CompareOp::NotEq => (actual - threshold).abs() >= f64::EPSILON,
+    };
+
+    AssertionResult {
+        metric: assertion.metric.clone(),
+        expected: assertion.value.clone(),
+        actual,
+        passed,
+    }
+}
+
+/// Run all assertions in an eval block against provided metrics.
+///
+/// `metrics` is a function that returns the actual value for a given metric name.
+#[must_use]
+pub fn run_eval<F>(eval: &EvalDef, metrics: F) -> EvalResult
+where
+    F: Fn(&str) -> Option<f64>,
+{
+    let assertions: Vec<AssertionResult> = eval
+        .assertions
+        .iter()
+        .map(|a| {
+            let actual = metrics(&a.metric).unwrap_or(0.0);
+            check_assertion(a, actual)
+        })
+        .collect();
+
+    let passed = assertions.iter().all(|a| a.passed);
+
+    EvalResult {
+        name: eval.name.clone(),
+        dataset: eval.dataset.clone(),
+        assertions,
+        passed,
+    }
+}
+
+fn parse_threshold(value: &str) -> f64 {
+    // Strip trailing % if present
+    let cleaned = value.trim_end_matches('%');
+    cleaned.parse::<f64>().unwrap_or(0.0)
+}

--- a/src/runtime/eval/tests.rs
+++ b/src/runtime/eval/tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::ast::{CompareOp, EvalAssertion, EvalDef, Span};
+
+fn make_assertion(metric: &str, op: CompareOp, value: &str) -> EvalAssertion {
+    EvalAssertion {
+        metric: metric.to_string(),
+        op,
+        value: value.to_string(),
+        span: Span::new(0, 0),
+    }
+}
+
+#[test]
+fn check_gt_passes() {
+    let a = make_assertion("accuracy", CompareOp::Gt, "90");
+    let result = check_assertion(&a, 95.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn check_gt_fails() {
+    let a = make_assertion("accuracy", CompareOp::Gt, "90");
+    let result = check_assertion(&a, 85.0);
+    assert!(!result.passed);
+}
+
+#[test]
+fn check_lt_passes() {
+    let a = make_assertion("latency", CompareOp::Lt, "2000");
+    let result = check_assertion(&a, 1500.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn check_gte_passes() {
+    let a = make_assertion("accuracy", CompareOp::GtEq, "90");
+    let result = check_assertion(&a, 90.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn check_eq_passes() {
+    let a = make_assertion("count", CompareOp::Eq, "42");
+    let result = check_assertion(&a, 42.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn check_neq_passes() {
+    let a = make_assertion("errors", CompareOp::NotEq, "0");
+    let result = check_assertion(&a, 3.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn check_percentage_threshold() {
+    let a = make_assertion("accuracy", CompareOp::Gt, "90%");
+    let result = check_assertion(&a, 95.0);
+    assert!(result.passed);
+}
+
+#[test]
+fn run_eval_all_pass() {
+    let eval = EvalDef {
+        name: Some("quality".to_string()),
+        dataset: "test.jsonl".to_string(),
+        assertions: vec![
+            make_assertion("accuracy", CompareOp::Gt, "90"),
+            make_assertion("latency", CompareOp::Lt, "2000"),
+        ],
+        on_failure: None,
+        span: Span::new(0, 0),
+    };
+
+    let result = run_eval(&eval, |metric| match metric {
+        "accuracy" => Some(95.0),
+        "latency" => Some(1500.0),
+        _ => None,
+    });
+
+    assert!(result.passed);
+    assert_eq!(result.assertions.len(), 2);
+}
+
+#[test]
+fn run_eval_one_fails() {
+    let eval = EvalDef {
+        name: Some("quality".to_string()),
+        dataset: "test.jsonl".to_string(),
+        assertions: vec![
+            make_assertion("accuracy", CompareOp::Gt, "90"),
+            make_assertion("latency", CompareOp::Lt, "1000"),
+        ],
+        on_failure: None,
+        span: Span::new(0, 0),
+    };
+
+    let result = run_eval(&eval, |metric| match metric {
+        "accuracy" => Some(95.0),
+        "latency" => Some(1500.0),
+        _ => None,
+    });
+
+    assert!(!result.passed);
+    assert!(result.assertions[0].passed);
+    assert!(!result.assertions[1].passed);
+}
+
+#[test]
+fn run_eval_missing_metric_defaults_to_zero() {
+    let eval = EvalDef {
+        name: None,
+        dataset: "test.jsonl".to_string(),
+        assertions: vec![make_assertion("missing", CompareOp::Gt, "0")],
+        on_failure: None,
+        span: Span::new(0, 0),
+    };
+
+    let result = run_eval(&eval, |_| None);
+    assert!(!result.passed); // 0.0 is not > 0.0
+}

--- a/src/runtime/memory/mod.rs
+++ b/src/runtime/memory/mod.rs
@@ -1,0 +1,122 @@
+//! Agent memory system with tiered storage.
+//!
+//! Three tiers: working (in-process), session (persisted per session),
+//! and knowledge (long-term retrieval).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[cfg(test)]
+mod tests;
+
+/// A memory entry with metadata.
+#[derive(Debug, Clone)]
+pub struct MemoryEntry {
+    pub key: String,
+    pub value: String,
+    pub tier: MemoryTier,
+    pub created_at_ms: u64,
+    pub ttl_ms: Option<u64>,
+}
+
+/// Memory tier matching the DSL's tier definitions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemoryTier {
+    Working,
+    Session,
+    Knowledge,
+}
+
+/// In-process memory store for agent state.
+///
+/// Working memory lives in-process and is cleared per run.
+/// Session memory persists across runs (would use file/db in production).
+/// Knowledge memory is read-only retrieval (would use embeddings in production).
+pub struct MemoryStore {
+    working: Mutex<HashMap<String, String>>,
+    session: Mutex<HashMap<String, String>>,
+}
+
+impl MemoryStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            working: Mutex::new(HashMap::new()),
+            session: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Store a value in working memory.
+    pub fn set_working(&self, key: impl Into<String>, value: impl Into<String>) {
+        self.working
+            .lock()
+            .expect("working memory mutex poisoned")
+            .insert(key.into(), value.into());
+    }
+
+    /// Retrieve from working memory.
+    #[must_use]
+    pub fn get_working(&self, key: &str) -> Option<String> {
+        self.working
+            .lock()
+            .expect("working memory mutex poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    /// Store a value in session memory (persists across turns).
+    pub fn set_session(&self, key: impl Into<String>, value: impl Into<String>) {
+        self.session
+            .lock()
+            .expect("session memory mutex poisoned")
+            .insert(key.into(), value.into());
+    }
+
+    /// Retrieve from session memory.
+    #[must_use]
+    pub fn get_session(&self, key: &str) -> Option<String> {
+        self.session
+            .lock()
+            .expect("session memory mutex poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    /// Get from any tier (working first, then session).
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<String> {
+        self.get_working(key).or_else(|| self.get_session(key))
+    }
+
+    /// Clear working memory (called between runs).
+    pub fn clear_working(&self) {
+        self.working
+            .lock()
+            .expect("working memory mutex poisoned")
+            .clear();
+    }
+
+    /// Number of entries in working memory.
+    #[must_use]
+    pub fn working_len(&self) -> usize {
+        self.working
+            .lock()
+            .expect("working memory mutex poisoned")
+            .len()
+    }
+
+    /// Number of entries in session memory.
+    #[must_use]
+    pub fn session_len(&self) -> usize {
+        self.session
+            .lock()
+            .expect("session memory mutex poisoned")
+            .len()
+    }
+}
+
+impl Default for MemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/runtime/memory/tests.rs
+++ b/src/runtime/memory/tests.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[test]
+fn working_memory_set_get() {
+    let store = MemoryStore::new();
+    store.set_working("key1", "value1");
+    assert_eq!(store.get_working("key1"), Some("value1".to_string()));
+}
+
+#[test]
+fn working_memory_missing_key() {
+    let store = MemoryStore::new();
+    assert_eq!(store.get_working("missing"), None);
+}
+
+#[test]
+fn session_memory_set_get() {
+    let store = MemoryStore::new();
+    store.set_session("session_key", "session_value");
+    assert_eq!(
+        store.get_session("session_key"),
+        Some("session_value".to_string())
+    );
+}
+
+#[test]
+fn get_checks_working_first() {
+    let store = MemoryStore::new();
+    store.set_working("key", "working_value");
+    store.set_session("key", "session_value");
+    assert_eq!(store.get("key"), Some("working_value".to_string()));
+}
+
+#[test]
+fn get_falls_back_to_session() {
+    let store = MemoryStore::new();
+    store.set_session("key", "session_value");
+    assert_eq!(store.get("key"), Some("session_value".to_string()));
+}
+
+#[test]
+fn clear_working_removes_entries() {
+    let store = MemoryStore::new();
+    store.set_working("key1", "v1");
+    store.set_working("key2", "v2");
+    assert_eq!(store.working_len(), 2);
+
+    store.clear_working();
+    assert_eq!(store.working_len(), 0);
+    assert_eq!(store.get_working("key1"), None);
+}
+
+#[test]
+fn clear_working_does_not_affect_session() {
+    let store = MemoryStore::new();
+    store.set_working("wk", "working");
+    store.set_session("sk", "session");
+
+    store.clear_working();
+    assert_eq!(store.get_working("wk"), None);
+    assert_eq!(store.get_session("sk"), Some("session".to_string()));
+}
+
+#[test]
+fn overwrite_working_value() {
+    let store = MemoryStore::new();
+    store.set_working("key", "v1");
+    store.set_working("key", "v2");
+    assert_eq!(store.get_working("key"), Some("v2".to_string()));
+    assert_eq!(store.working_len(), 1);
+}
+
+#[test]
+fn default_creates_empty_store() {
+    let store = MemoryStore::default();
+    assert_eq!(store.working_len(), 0);
+    assert_eq!(store.session_len(), 0);
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2,6 +2,8 @@ pub mod alerting;
 pub mod audit;
 pub mod budget;
 pub mod engine;
+pub mod eval;
+pub mod memory;
 pub mod events;
 pub mod execution;
 pub mod executor;
@@ -13,6 +15,7 @@ pub mod permissions;
 pub mod provider;
 pub mod registry;
 pub mod sandbox;
+pub mod schedule;
 pub mod webhook;
 pub mod workflow;
 

--- a/src/runtime/schedule/mod.rs
+++ b/src/runtime/schedule/mod.rs
@@ -1,0 +1,99 @@
+//! Schedule evaluation for workflow triggers.
+//!
+//! Evaluates `ScheduleExpr` definitions to determine when workflows
+//! should run. Supports daily-at, every-N-hours/minutes, and cron expressions.
+
+use crate::ast::ScheduleExpr;
+
+#[cfg(test)]
+mod tests;
+
+/// A resolved schedule with the next run time as seconds from now.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NextRun {
+    /// Seconds until the next scheduled run.
+    pub seconds_from_now: u64,
+    /// Human-readable description of the schedule.
+    pub description: String,
+}
+
+/// Evaluate a schedule expression and return the interval in seconds.
+///
+/// For `daily at` schedules, this returns 86400 (24 hours).
+/// For `every N hours/minutes`, this returns the interval directly.
+/// For cron expressions, this returns an approximate interval.
+#[must_use]
+pub fn interval_seconds(expr: &ScheduleExpr) -> u64 {
+    match expr {
+        ScheduleExpr::DailyAt { .. } => 86_400,
+        ScheduleExpr::EveryNHours { hours } => hours * 3_600,
+        ScheduleExpr::EveryNMinutes { minutes } => minutes * 60,
+        ScheduleExpr::Cron { .. } => {
+            // Without a full cron parser, return a default interval.
+            // In production, this would use a cron library to compute
+            // the next occurrence.
+            3_600 // default to hourly
+        }
+    }
+}
+
+/// Describe a schedule expression in human-readable form.
+#[must_use]
+pub fn describe(expr: &ScheduleExpr) -> String {
+    match expr {
+        ScheduleExpr::DailyAt { time } => format!("daily at {time}"),
+        ScheduleExpr::EveryNHours { hours } => {
+            if *hours == 1 {
+                "every hour".to_string()
+            } else {
+                format!("every {hours} hours")
+            }
+        }
+        ScheduleExpr::EveryNMinutes { minutes } => {
+            if *minutes == 1 {
+                "every minute".to_string()
+            } else {
+                format!("every {minutes} minutes")
+            }
+        }
+        ScheduleExpr::Cron { expr } => format!("cron: {expr}"),
+    }
+}
+
+/// Validate a schedule expression for basic correctness.
+///
+/// # Errors
+/// Returns a description of the problem if the schedule is invalid.
+pub fn validate(expr: &ScheduleExpr) -> Result<(), String> {
+    match expr {
+        ScheduleExpr::DailyAt { time } => {
+            if time.is_empty() {
+                return Err("daily schedule requires a time".to_string());
+            }
+            Ok(())
+        }
+        ScheduleExpr::EveryNHours { hours } => {
+            if *hours == 0 || *hours > 168 {
+                return Err(format!("invalid interval: {hours} hours (must be 1-168)"));
+            }
+            Ok(())
+        }
+        ScheduleExpr::EveryNMinutes { minutes } => {
+            if *minutes == 0 || *minutes > 10_080 {
+                return Err(format!("invalid interval: {minutes} minutes (must be 1-10080)"));
+            }
+            Ok(())
+        }
+        ScheduleExpr::Cron { expr } => {
+            // Basic validation: cron should have 5 fields
+            let fields: Vec<&str> = expr.split_whitespace().collect();
+            if fields.len() != 5 {
+                return Err(format!(
+                    "cron expression should have 5 fields, got {}",
+                    fields.len()
+                ));
+            }
+            Ok(())
+        }
+    }
+}

--- a/src/runtime/schedule/tests.rs
+++ b/src/runtime/schedule/tests.rs
@@ -1,0 +1,108 @@
+use super::*;
+use crate::ast::ScheduleExpr;
+
+#[test]
+fn daily_at_interval_is_24_hours() {
+    let expr = ScheduleExpr::DailyAt {
+        time: "2am".to_string(),
+    };
+    assert_eq!(interval_seconds(&expr), 86_400);
+}
+
+#[test]
+fn every_6_hours_interval() {
+    let expr = ScheduleExpr::EveryNHours { hours: 6 };
+    assert_eq!(interval_seconds(&expr), 21_600);
+}
+
+#[test]
+fn every_30_minutes_interval() {
+    let expr = ScheduleExpr::EveryNMinutes { minutes: 30 };
+    assert_eq!(interval_seconds(&expr), 1_800);
+}
+
+#[test]
+fn cron_default_interval() {
+    let expr = ScheduleExpr::Cron {
+        expr: "0 9 * * *".to_string(),
+    };
+    assert_eq!(interval_seconds(&expr), 3_600);
+}
+
+#[test]
+fn describe_daily() {
+    let expr = ScheduleExpr::DailyAt {
+        time: "2am".to_string(),
+    };
+    assert_eq!(describe(&expr), "daily at 2am");
+}
+
+#[test]
+fn describe_every_1_hour() {
+    let expr = ScheduleExpr::EveryNHours { hours: 1 };
+    assert_eq!(describe(&expr), "every hour");
+}
+
+#[test]
+fn describe_every_n_hours() {
+    let expr = ScheduleExpr::EveryNHours { hours: 6 };
+    assert_eq!(describe(&expr), "every 6 hours");
+}
+
+#[test]
+fn describe_every_1_minute() {
+    let expr = ScheduleExpr::EveryNMinutes { minutes: 1 };
+    assert_eq!(describe(&expr), "every minute");
+}
+
+#[test]
+fn describe_cron() {
+    let expr = ScheduleExpr::Cron {
+        expr: "0 9 * * 1-5".to_string(),
+    };
+    assert_eq!(describe(&expr), "cron: 0 9 * * 1-5");
+}
+
+#[test]
+fn validate_daily_ok() {
+    let expr = ScheduleExpr::DailyAt {
+        time: "14:30".to_string(),
+    };
+    assert!(validate(&expr).is_ok());
+}
+
+#[test]
+fn validate_daily_empty_time() {
+    let expr = ScheduleExpr::DailyAt {
+        time: String::new(),
+    };
+    assert!(validate(&expr).is_err());
+}
+
+#[test]
+fn validate_hours_zero() {
+    let expr = ScheduleExpr::EveryNHours { hours: 0 };
+    assert!(validate(&expr).is_err());
+}
+
+#[test]
+fn validate_hours_too_large() {
+    let expr = ScheduleExpr::EveryNHours { hours: 200 };
+    assert!(validate(&expr).is_err());
+}
+
+#[test]
+fn validate_cron_valid() {
+    let expr = ScheduleExpr::Cron {
+        expr: "0 9 * * *".to_string(),
+    };
+    assert!(validate(&expr).is_ok());
+}
+
+#[test]
+fn validate_cron_wrong_fields() {
+    let expr = ScheduleExpr::Cron {
+        expr: "0 9 *".to_string(),
+    };
+    assert!(validate(&expr).is_err());
+}


### PR DESCRIPTION
Three runtime modules that bring parsed features closer to execution.

### Schedule evaluator (#130)
- `interval_seconds()` — compute interval from schedule expressions
- `describe()` — human-readable schedule descriptions
- `validate()` — basic correctness checks (empty times, invalid intervals, cron field count)
- 15 tests

### Eval assertion runner (#123)
- `check_assertion()` — evaluate a single metric against a threshold with all 6 operators
- `run_eval()` — run all assertions in an eval block against a metrics provider function
- Handles percentages, missing metrics (default to 0), all CompareOp variants
- 10 tests

### Memory store (#124)
- Two-tier in-process store: working (cleared per run) + session (persists across turns)
- `get()` checks working first, falls back to session
- Thread-safe via Mutex
- 9 tests

556 tests passing, zero clippy warnings.

Closes #123, #124, #130