### PR TITLE
feat: LSP server + VSCode extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +157,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -176,6 +187,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -323,6 +340,19 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -583,6 +613,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -964,6 +1000,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,7 +1095,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1112,6 +1161,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1180,7 +1249,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1230,8 +1299,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
- "tower",
+ "tower 0.5.3",
  "tower-http",
+ "tower-lsp",
  "wiremock",
 ]
 
@@ -1266,7 +1336,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1295,7 +1365,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1368,7 +1438,7 @@ version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1443,6 +1513,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1570,7 +1651,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -1712,6 +1793,20 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -1732,14 +1827,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1749,6 +1844,40 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tower-service"
@@ -1764,7 +1893,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1822,6 +1963,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1968,7 +2110,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2300,7 +2442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ axum = { version = "0.8.8", features = ["json"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 tower = { version = "0.5.3", features = ["util"] }
 sha2 = "0.10.9"
+tower-lsp = "0.20"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,26 @@
+# Rein Language Support for VSCode
+
+Syntax highlighting, diagnostics, completions, and hover docs for `.rein` files.
+
+## Features
+
+- **Syntax highlighting** — keywords, strings, numbers, currencies, operators, comments
+- **Real-time diagnostics** — parse errors and validation warnings as you type
+- **Completions** — keyword completions with descriptions
+- **Hover documentation** — hover over keywords to see syntax and examples
+
+## Requirements
+
+The `rein` binary must be installed and available in your PATH (or configure `rein.serverPath`).
+
+## Installation
+
+1. Install `rein`: `cargo install --git https://github.com/delamain-labs/rein.git`
+2. Install this extension (or copy to `~/.vscode/extensions/rein-lang/`)
+3. Open a `.rein` file
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `rein.serverPath` | `rein` | Path to the rein binary |

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,29 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "folding": {
+    "markers": {
+      "start": "\\{",
+      "end": "\\}"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "rein-lang",
+  "displayName": "Rein Language Support",
+  "description": "Language support for .rein files — AI agent governance DSL",
+  "version": "0.1.0",
+  "publisher": "delamain-labs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/delamain-labs/rein"
+  },
+  "categories": ["Programming Languages", "Linters"],
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onLanguage:rein"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "rein",
+        "aliases": ["Rein", "rein"],
+        "extensions": [".rein"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "rein",
+        "scopeName": "source.rein",
+        "path": "./syntaxes/rein.tmLanguage.json"
+      }
+    ],
+    "configuration": {
+      "title": "Rein",
+      "properties": {
+        "rein.serverPath": {
+          "type": "string",
+          "default": "rein",
+          "description": "Path to the rein binary for the language server"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.75.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+import { workspace, ExtensionContext } from 'vscode';
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind,
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient;
+
+export function activate(context: ExtensionContext) {
+    const config = workspace.getConfiguration('rein');
+    const serverPath = config.get<string>('serverPath', 'rein');
+
+    const serverOptions: ServerOptions = {
+        command: serverPath,
+        args: ['lsp'],
+        transport: TransportKind.stdio,
+    };
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'rein' }],
+        synchronize: {
+            fileEvents: workspace.createFileSystemWatcher('**/*.rein'),
+        },
+    };
+
+    client = new LanguageClient(
+        'reinLanguageServer',
+        'Rein Language Server',
+        serverOptions,
+        clientOptions
+    );
+
+    client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}

--- a/editors/vscode/syntaxes/rein.tmLanguage.json
+++ b/editors/vscode/syntaxes/rein.tmLanguage.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Rein",
+  "scopeName": "source.rein",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#numbers" },
+    { "include": "#keywords" },
+    { "include": "#operators" },
+    { "include": "#functions" },
+    { "include": "#types" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        { "name": "comment.line.double-slash.rein", "match": "//.*$" },
+        { "name": "comment.line.hash.rein", "match": "#.*$" },
+        { "name": "comment.block.rein", "begin": "/\\*", "end": "\\*/", "contentName": "comment.block.rein" }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        { "name": "string.quoted.double.rein", "begin": "\"", "end": "\"", "patterns": [
+          { "name": "constant.character.escape.rein", "match": "\\\\." }
+        ]}
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        { "name": "constant.numeric.currency.rein", "match": "[$€£¥]\\d+(\\.\\d+)?" },
+        { "name": "constant.numeric.percentage.rein", "match": "\\b\\d+(\\.\\d+)?%" },
+        { "name": "constant.numeric.rein", "match": "\\b\\d+(\\.\\d+)?\\b" }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.rein",
+          "match": "\\b(agent|workflow|step|provider|defaults|archetype|policy|type|tool|guardrails|circuit_breaker|observe|fleet|channel|eval|consensus|approval|escalate|secrets|memory|schedule|scenario|import|parallel|route_on)\\b"
+        },
+        {
+          "name": "keyword.other.rein",
+          "match": "\\b(model|can|cannot|budget|trigger|goal|when|from|per|up_to|on|failure|retry|then|fallback|one_of|send_to|input|output|for|each|auto|resolve|assert|dataset|within|via|approve|collaborate|mode|timeout|require|agree|strategy|given|expect)\\b"
+        },
+        {
+          "name": "keyword.operator.logical.rein",
+          "match": "\\b(and|or|is|not)\\b"
+        },
+        {
+          "name": "constant.language.rein",
+          "match": "\\b(on|off|true|false|exponential|linear|fixed|majority|unanimous)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        { "name": "keyword.operator.comparison.rein", "match": "==|!=|<=|>=|<|>" },
+        { "name": "keyword.operator.pipe.rein", "match": "\\|>" },
+        { "name": "keyword.operator.arrow.rein", "match": "->" },
+        { "name": "keyword.operator.range.rein", "match": "\\.\\." }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        { "name": "entity.name.function.rein", "match": "\\b(env)\\b(?=\\()" }
+      ]
+    },
+    "types": {
+      "patterns": [
+        { "name": "storage.type.rein", "match": "\\b(int|float|string|bool)\\b" },
+        { "name": "keyword.other.tier.rein", "match": "\\b(tier|working|session|knowledge)\\b" }
+      ]
+    }
+  }
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod config;
 pub mod error;
 pub mod lexer;
+pub mod lsp;
 pub mod lockfile;
 pub mod parser;
 pub mod runtime;

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,287 @@
+//! Language Server Protocol implementation for Rein.
+//!
+//! Provides real-time diagnostics, hover info, and completion
+//! for `.rein` files in any LSP-compatible editor.
+
+use std::sync::Mutex;
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionOptions, CompletionParams, CompletionResponse,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DiagnosticSeverity, Hover, HoverContents, HoverParams, HoverProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, MarkupContent, MarkupKind, MessageType,
+    Position, Range, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
+};
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+use crate::parser::parse;
+use crate::validator;
+
+#[cfg(test)]
+mod tests;
+
+/// The Rein language server backend.
+pub struct ReinLanguageServer {
+    client: Client,
+    /// Cache of open document contents.
+    documents: Mutex<std::collections::HashMap<Url, String>>,
+}
+
+impl ReinLanguageServer {
+    fn new(client: Client) -> Self {
+        Self {
+            client,
+            documents: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Validate a document and publish diagnostics.
+    async fn validate_document(&self, uri: Url, text: &str) {
+        let diagnostics = compute_diagnostics(text);
+        self.client
+            .publish_diagnostics(uri, diagnostics, None)
+            .await;
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for ReinLanguageServer {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![":".to_string(), " ".to_string()]),
+                    ..CompletionOptions::default()
+                }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                ..ServerCapabilities::default()
+            },
+            ..InitializeResult::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "Rein language server initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
+        let text = params.text_document.text.clone();
+        self.documents
+            .lock()
+            .expect("documents mutex poisoned")
+            .insert(uri.clone(), text.clone());
+        self.validate_document(uri, &text).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
+        if let Some(change) = params.content_changes.into_iter().last() {
+            let text = change.text.clone();
+            self.documents
+                .lock()
+                .expect("documents mutex poisoned")
+                .insert(uri.clone(), text.clone());
+            self.validate_document(uri, &text).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        self.documents
+            .lock()
+            .expect("documents mutex poisoned")
+            .remove(&params.text_document.uri);
+    }
+
+    async fn completion(&self, _params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let items = KEYWORD_COMPLETIONS
+            .iter()
+            .map(|(label, detail)| CompletionItem {
+                label: (*label).to_string(),
+                kind: Some(CompletionItemKind::KEYWORD),
+                detail: Some((*detail).to_string()),
+                ..CompletionItem::default()
+            })
+            .collect();
+
+        Ok(Some(CompletionResponse::Array(items)))
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+
+        let docs = self.documents.lock().expect("documents mutex poisoned");
+        let Some(text) = docs.get(uri) else {
+            return Ok(None);
+        };
+
+        let word = word_at_position(text, pos);
+        let hover_text = keyword_docs(&word);
+
+        Ok(hover_text.map(|text| Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: text,
+            }),
+            range: None,
+        }))
+    }
+}
+
+/// Compute LSP diagnostics from Rein source text.
+pub fn compute_diagnostics(text: &str) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    // Parse errors
+    if let Err(e) = parse(text) {
+        let (line, col) = offset_to_line_col(text, e.span.start);
+        diagnostics.push(tower_lsp::lsp_types::Diagnostic {
+            range: Range {
+                start: Position::new(line, col),
+                end: Position::new(line, col + 1),
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("rein".to_string()),
+            message: e.message.clone(),
+            ..tower_lsp::lsp_types::Diagnostic::default()
+        });
+        return diagnostics;
+    }
+
+    // Validation warnings/errors
+    if let Ok(file) = parse(text) {
+        for diag in validator::validate(&file) {
+            let (line, col) = offset_to_line_col(text, diag.span.start);
+            let severity = if diag.is_error() {
+                DiagnosticSeverity::ERROR
+            } else {
+                DiagnosticSeverity::WARNING
+            };
+            diagnostics.push(tower_lsp::lsp_types::Diagnostic {
+                range: Range {
+                    start: Position::new(line, col),
+                    end: Position::new(line, col + 1),
+                },
+                severity: Some(severity),
+                source: Some("rein".to_string()),
+                message: diag.message.clone(),
+                ..tower_lsp::lsp_types::Diagnostic::default()
+            });
+        }
+    }
+
+    diagnostics
+}
+
+fn offset_to_line_col(text: &str, offset: usize) -> (u32, u32) {
+    let mut line = 0u32;
+    let mut col = 0u32;
+    for (i, ch) in text.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+fn word_at_position(text: &str, pos: Position) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let line_idx = pos.line as usize;
+    if line_idx >= lines.len() {
+        return String::new();
+    }
+    let line = lines[line_idx];
+    let col = pos.character as usize;
+    if col >= line.len() {
+        return String::new();
+    }
+
+    let bytes = line.as_bytes();
+    let mut start = col;
+    let mut end = col;
+
+    while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+        start -= 1;
+    }
+    while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+        end += 1;
+    }
+
+    line[start..end].to_string()
+}
+
+const KEYWORD_COMPLETIONS: &[(&str, &str)] = &[
+    ("agent", "Define an AI agent with capabilities and constraints"),
+    ("workflow", "Define a multi-step workflow"),
+    ("step", "A unit of work within a workflow"),
+    ("provider", "Configure an AI model provider"),
+    ("defaults", "Set project-wide defaults"),
+    ("archetype", "Reusable agent template"),
+    ("policy", "Conditional governance rules"),
+    ("type", "Custom type definition"),
+    ("tool", "External tool integration"),
+    ("guardrails", "Safety constraints"),
+    ("circuit_breaker", "Failure detection and recovery"),
+    ("observe", "Observability configuration"),
+    ("fleet", "Multi-agent group definition"),
+    ("channel", "Communication channel"),
+    ("eval", "Quality gate with assertions"),
+    ("consensus", "Multi-agent verification"),
+    ("approval", "Human-in-the-loop gate"),
+    ("escalate", "Agent-to-human handoff"),
+    ("secrets", "Vault-based secret management"),
+    ("memory", "Agent memory system"),
+    ("schedule", "Time-based triggers"),
+    ("scenario", "Declarative test definition"),
+    ("import", "Import from other .rein files"),
+    ("model", "AI model to use"),
+    ("can", "Allowed capabilities"),
+    ("cannot", "Denied capabilities"),
+    ("budget", "Spending limit"),
+    ("trigger", "Event that starts a workflow"),
+    ("goal", "Task description for a step"),
+    ("when", "Guard condition"),
+    ("from", "Inherit from archetype"),
+    ("env", "Environment variable reference"),
+];
+
+fn keyword_docs(word: &str) -> Option<String> {
+    let docs = match word {
+        "agent" => "## agent\n\nDefine an AI agent with model, capabilities, and constraints.\n\n```rein\nagent name {\n    model: gpt-4\n    can: action1, action2\n    cannot: action3\n    budget: $100 per day\n}\n```",
+        "workflow" => "## workflow\n\nDefine a multi-step workflow with triggers and steps.\n\n```rein\nworkflow name {\n    trigger: event\n    step classify { agent: bot, goal: \"...\" }\n}\n```",
+        "step" => "## step\n\nA unit of work within a workflow.\n\n```rein\nstep name {\n    agent: agent_name\n    goal: \"Task description\"\n    when: condition\n}\n```",
+        "provider" => "## provider\n\nConfigure an AI model provider.\n\n```rein\nprovider openai {\n    model: gpt-4\n    key: env(\"OPENAI_API_KEY\")\n}\n```",
+        "budget" => "## budget\n\nSpending constraint with currency and time period.\n\n```rein\nbudget: $100 per day\nbudget: €500 per month\n```",
+        "can" | "cannot" => "## can / cannot\n\nCapability lists. Use `up_to` for constrained capabilities.\n\n```rein\ncan: read_files, search_web\ncan: issue_refunds up_to $500\ncannot: delete_data\n```",
+        "when" => "## when\n\nGuard condition on steps. Supports comparison operators and boolean logic.\n\n```rein\nwhen: confidence < 70%\nwhen: status == \"critical\" and priority > 3\n```",
+        "env" => "## env()\n\nReference an environment variable with optional default.\n\n```rein\nkey: env(\"API_KEY\")\nkey: env(\"API_KEY\", \"default_value\")\n```",
+        _ => return None,
+    };
+    Some(docs.to_string())
+}
+
+/// Start the LSP server on stdin/stdout.
+pub async fn run_lsp() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(ReinLanguageServer::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+#[test]
+fn valid_file_no_diagnostics() {
+    let text = r#"agent test { model: openai }"#;
+    let diags = compute_diagnostics(text);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn parse_error_produces_diagnostic() {
+    let text = r#"agent { }"#;
+    let diags = compute_diagnostics(text);
+    assert!(!diags.is_empty());
+    assert_eq!(diags[0].severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn offset_to_line_col_first_line() {
+    let text = "agent test { model: openai }";
+    let (line, col) = offset_to_line_col(text, 6);
+    assert_eq!(line, 0);
+    assert_eq!(col, 6);
+}
+
+#[test]
+fn offset_to_line_col_second_line() {
+    let text = "line one\nline two";
+    let (line, col) = offset_to_line_col(text, 10);
+    assert_eq!(line, 1);
+    assert_eq!(col, 1);
+}
+
+#[test]
+fn word_at_position_extracts_keyword() {
+    let text = "agent test { model: openai }";
+    let word = word_at_position(text, Position::new(0, 2));
+    assert_eq!(word, "agent");
+}
+
+#[test]
+fn word_at_position_extracts_ident() {
+    let text = "agent my_agent { model: openai }";
+    let word = word_at_position(text, Position::new(0, 8));
+    assert_eq!(word, "my_agent");
+}
+
+#[test]
+fn keyword_docs_returns_agent() {
+    let docs = keyword_docs("agent");
+    assert!(docs.is_some());
+    assert!(docs.unwrap().contains("agent"));
+}
+
+#[test]
+fn keyword_docs_returns_none_for_unknown() {
+    assert!(keyword_docs("foobar").is_none());
+}
+
+#[test]
+fn completions_include_agent() {
+    let has_agent = KEYWORD_COMPLETIONS.iter().any(|(k, _)| *k == "agent");
+    assert!(has_agent);
+}
+
+#[test]
+fn completions_include_workflow() {
+    let has_wf = KEYWORD_COMPLETIONS.iter().any(|(k, _)| *k == "workflow");
+    assert!(has_wf);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ enum Command {
         /// Path to the .rein file
         file: std::path::PathBuf,
     },
+    /// Start the Rein Language Server (LSP)
+    Lsp,
     /// Start the Rein API server
     Serve {
         /// Path to the .rein file to serve
@@ -108,6 +110,10 @@ async fn main() {
         Command::Explain { file } => {
             let exit_code = commands::explain::run_explain(&file);
             process::exit(exit_code);
+        }
+        Command::Lsp => {
+            let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+            rt.block_on(rein::lsp::run_lsp());
         }
         Command::Serve { file, host, port } => {
             let exit_code = commands::serve::run_serve(&file, &host, port);


### PR DESCRIPTION
## LSP Server (#100)
- Full Language Server Protocol implementation via `tower-lsp`
- `rein lsp` command starts the server on stdin/stdout
- **Real-time diagnostics**: parse errors + validation warnings published on every keystroke
- **Completions**: 30+ keyword completions with descriptions
- **Hover docs**: syntax examples for agent, workflow, step, provider, budget, can/cannot, when, env()
- 10 tests covering diagnostics, position mapping, word extraction, hover, completions

## VSCode Extension (#101)
- Full TextMate grammar for syntax highlighting:
  - Block keywords (agent, workflow, step, etc.)
  - Field keywords (model, can, budget, etc.)
  - Operators, currencies, percentages, strings, comments
  - Built-in types, functions (env), constants
- Language configuration (brackets, comments, folding)
- LSP client that connects to `rein lsp`
- Configurable server path

566 tests passing, zero clippy warnings.

Closes #100, #101