### PR TITLE
feat(dist): rename crate to rein-lang for crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "rein"
+name = "rein-lang"
 version = "0.1.0"
 dependencies = [
  "ariadne",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rein"
+name = "rein-lang"
 version = "0.1.0"
 edition = "2024"
 description = "A declarative language and runtime for AI agent orchestration"


### PR DESCRIPTION
Renames the crate package from `rein` to `rein-lang` ("rein" was taken on crates.io). Binary still installs as `rein`, lib still imports as `rein`. All 576 tests pass. Closes #251 once published.