### PR TITLE
docs: update install to cargo install rein-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ AI agents are shipping to production, but **trust** is the bottleneck, not capab
 ## Install
 
 ```bash
-# From source
-cargo install --path .
+# From crates.io
+cargo install rein-lang
 
-# Or build from the repo
+# Or from source
 git clone https://github.com/delamain-labs/rein.git
 cd rein && cargo build --release
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,13 @@ Define governance for an AI agent in 5 minutes. No API keys required.
 
 ## Install
 
-**From source (requires Rust):**
+**From crates.io (requires Rust):**
+
+```bash
+cargo install rein-lang
+```
+
+**Or from source:**
 
 ```bash
 git clone https://github.com/delamain-labs/rein.git
@@ -212,7 +218,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rein
-        run: cargo install --git https://github.com/delamain-labs/rein.git
+        run: cargo install rein-lang
       - name: Validate
         run: rein validate agents/*.rein
       - name: Check formatting


### PR DESCRIPTION
Now that rein-lang is published on crates.io, update all install instructions.