### PR TITLE
feat(cli): wire AgentEngine to rein run + example files

### DIFF
--- a/examples/circuit-breaker.rein
+++ b/examples/circuit-breaker.rein
@@ -1,0 +1,20 @@
+// Circuit breaker that trips after 3 failures in 5 minutes.
+// Try: rein validate examples/circuit-breaker.rein --strict
+
+agent api_agent {
+    model: openai
+
+    can [
+        api.call
+        api.retry
+    ]
+
+    cannot [api.delete]
+
+    budget: $20 per hour
+}
+
+circuit_breaker api_protection {
+    open after: 3 failures in 5 min
+    half_open after: 2 min
+}

--- a/examples/hello.rein
+++ b/examples/hello.rein
@@ -1,0 +1,5 @@
+// A minimal agent. Run with: rein run examples/hello.rein -m "Hello!"
+agent hello {
+    model: openai
+    can [chat.respond]
+}

--- a/examples/policy-tiers.rein
+++ b/examples/policy-tiers.rein
@@ -1,0 +1,25 @@
+// Progressive trust: agents start supervised and earn autonomy.
+// Try: rein explain examples/policy-tiers.rein
+
+agent trading_bot {
+    model: anthropic
+
+    can [
+        market.read
+        market.analyze
+    ]
+
+    cannot [market.trade]
+
+    budget: $100 per day
+}
+
+policy {
+    tier supervised {
+        promote when accuracy > 95%
+    }
+    tier autonomous {
+        promote when accuracy > 99%
+    }
+    tier fully_autonomous {}
+}

--- a/examples/safe-agent.rein
+++ b/examples/safe-agent.rein
@@ -1,0 +1,25 @@
+// An agent with guardrails that block PII and toxicity.
+// Try: rein run examples/safe-agent.rein -m "What is 2+2?"
+
+agent support_bot {
+    model: openai
+
+    can [
+        chat.respond
+    ]
+
+    cannot [
+        admin.delete
+        admin.modify
+    ]
+
+    budget: $5 per request
+
+    guardrails {
+        output_filter {
+            pii_detection: redact
+            toxicity: block
+            prompt_injection: block
+        }
+    }
+}

--- a/examples/workflow.rein
+++ b/examples/workflow.rein
@@ -1,34 +1,42 @@
-// A support pipeline workflow with three stages.
+// A multi-step workflow with conditional routing.
+// Try: rein validate examples/workflow.rein --ast
 
 agent triage {
-    model: openai
-    can [
-        zendesk.read_ticket
-        zendesk.classify_ticket
-    ]
-    cannot [
-        zendesk.delete_ticket
-    ]
-}
-
-agent responder {
-    model: openai
-    can [
-        zendesk.read_ticket
-        zendesk.reply_ticket
-    ]
-}
-
-agent escalator {
     model: anthropic
+
     can [
-        zendesk.read_ticket
-        zendesk.escalate_ticket
-        slack.send_message
+        tickets.read
+        tickets.classify
     ]
+
+    cannot [tickets.delete]
+}
+
+agent resolver {
+    model: anthropic
+
+    can [
+        tickets.read
+        tickets.update
+        kb.search
+    ]
+
+    cannot [tickets.delete]
+
+    budget: $10 per request
 }
 
 workflow support_pipeline {
-    trigger: incoming_ticket
-    stages: [triage, responder, escalator]
+    trigger: ticket_created
+
+    step classify {
+        agent: triage
+        goal: "Classify the incoming support ticket by priority"
+    }
+
+    step resolve {
+        agent: resolver
+        goal: "Attempt to resolve the ticket automatically"
+        when: priority > 3
+    }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 pub fn run_agent(path: &std::path::Path, message: Option<&str>, dry_run: bool, otel: bool) -> i32 {
     let filename = path.to_string_lossy();
 
@@ -32,18 +34,119 @@ pub fn run_agent(path: &std::path::Path, message: Option<&str>, dry_run: bool, o
         return print_execution_plan(&file, message);
     }
 
-    if let Some(msg) = message {
-        println!("Message: {msg}");
+    let Some(agent) = file.agents.first() else {
+        eprintln!("error: no agents defined in '{filename}'");
+        return 1;
+    };
+
+    let user_message = message.unwrap_or("Hello");
+
+    // Resolve model to a provider.
+    let model_field = agent
+        .model
+        .as_ref()
+        .map_or("openai".to_string(), format_value_expr);
+
+    let provider_config = rein::runtime::provider::resolver::ProviderConfig {
+        openai_api_key: std::env::var("OPENAI_API_KEY").ok(),
+        openai_base_url: std::env::var("OPENAI_BASE_URL").ok(),
+        anthropic_api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+        anthropic_base_url: std::env::var("ANTHROPIC_BASE_URL").ok(),
+    };
+
+    let provider = match rein::runtime::provider::resolver::resolve(&model_field, &provider_config)
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            eprintln!("hint: set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable");
+            return 1;
+        }
+    };
+
+    // Build permission registry from agent capabilities.
+    let registry = rein::runtime::permissions::ToolRegistry::from_agent(agent);
+
+    // Build run config.
+    let config = rein::runtime::engine::RunConfig {
+        system_prompt: None,
+        max_turns: 10,
+        budget_cents: agent.budget.as_ref().map_or(0, |b| b.amount),
+    };
+
+    // Build engine with enforcement.
+    let executor = rein::runtime::executor::NoopExecutor;
+    let mut engine = rein::runtime::engine::AgentEngine::new(
+        provider.as_ref(),
+        &executor,
+        &registry,
+        Vec::new(),
+        config,
+    )
+    .with_stream(Box::new(rein::runtime::engine::StdoutStream));
+
+    // Attach guardrails if defined.
+    if let Some(ref guardrails_def) = agent.guardrails {
+        let guardrail_engine = rein::runtime::guardrails::GuardrailEngine::from_def(guardrails_def);
+        engine = engine.with_guardrails(guardrail_engine);
     }
 
-    if otel {
-        println!(
-            "Note: --otel flag is available. After execution, traces will be exported as OTLP JSON."
-        );
+    // Attach circuit breaker if defined.
+    if let Some(cb_def) = file.circuit_breakers.first() {
+        let cb = rein::runtime::circuit_breaker::CircuitBreaker::from_def(cb_def);
+        engine = engine.with_circuit_breaker(cb);
     }
 
-    println!("Runtime not yet implemented");
-    0
+    // Execute.
+    let start = Instant::now();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let result = rt.block_on(engine.run(user_message));
+
+    match result {
+        Ok(run_result) => {
+            let duration = start.elapsed();
+            eprintln!();
+            eprintln!("--- Run complete ---");
+            eprintln!("{}", run_result.trace.summary());
+            eprintln!("Duration: {duration:.2?}");
+
+            if otel {
+                write_otel_trace(&run_result.trace, &agent.name, duration);
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!();
+            eprintln!("Run failed: {e:?}");
+            1
+        }
+    }
+}
+
+fn write_otel_trace(
+    trace: &rein::runtime::RunTrace,
+    agent_name: &str,
+    duration: std::time::Duration,
+) {
+    let now = chrono::Utc::now();
+    let started = now - duration;
+    let structured = trace.to_structured(
+        agent_name,
+        &started.to_rfc3339(),
+        &now.to_rfc3339(),
+        duration.as_millis().try_into().unwrap_or(u64::MAX),
+    );
+
+    match rein::runtime::otel_export::to_otlp_json(&structured) {
+        Ok(json) => {
+            let path = format!("rein-trace-{}.json", now.format("%Y%m%d-%H%M%S"));
+            match std::fs::write(&path, &json) {
+                Ok(()) => eprintln!("OTLP trace written to {path}"),
+                Err(e) => eprintln!("Failed to write OTLP trace: {e}"),
+            }
+        }
+        Err(e) => eprintln!("Failed to serialize OTLP trace: {e}"),
+    }
 }
 
 fn format_value_expr(v: &rein::ast::ValueExpr) -> String {

--- a/src/runtime/executor/mod.rs
+++ b/src/runtime/executor/mod.rs
@@ -39,6 +39,23 @@ pub trait ToolExecutor: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Noop executor (for agents with no tools)
+// ---------------------------------------------------------------------------
+
+/// An executor that denies all tool calls. Use for chat-only agents.
+pub struct NoopExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for NoopExecutor {
+    async fn execute(&self, tool_call: &ToolCall) -> Result<ToolOutput, ExecutorError> {
+        Err(ExecutorError::NotFound(format!(
+            "{}.{}",
+            tool_call.namespace, tool_call.action
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mock executor
 // ---------------------------------------------------------------------------
 

--- a/src/runtime/policy/mod.rs
+++ b/src/runtime/policy/mod.rs
@@ -48,7 +48,7 @@ impl PolicyEngine {
                 let (metric, threshold) = t
                     .promote_when
                     .as_ref()
-                    .map_or((None, None), |when| extract_simple_comparison(when));
+                    .map_or((None, None), extract_simple_comparison);
                 TierState {
                     name: t.name.clone(),
                     promote_metric: metric,


### PR DESCRIPTION
## Summary

`rein run` now actually executes agents against real LLM providers instead of printing 'Runtime not yet implemented'.

### CLI Runtime Wiring
- Resolves model field to OpenAI/Anthropic provider via `resolver::resolve()`
- Reads API keys from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars
- Builds `ToolRegistry` from agent `can`/`cannot` capabilities
- Attaches guardrails engine from parsed guardrail blocks
- Attaches circuit breaker from parsed circuit_breaker blocks
- Outputs trace summary after run completes
- `--otel` flag writes OTLP JSON trace file
- Added `NoopExecutor` for chat-only agents (no tool calls)

### Example Files
- `examples/hello.rein` — minimal agent
- `examples/safe-agent.rein` — agent with guardrails (PII redaction, toxicity blocking)
- `examples/workflow.rein` — multi-step workflow with conditional routing
- `examples/circuit-breaker.rein` — failure protection
- `examples/policy-tiers.rein` — progressive trust tiers

Closes #258