### PR TITLE
fix(cli): budget display in explain, provider example in init

### DIFF
--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -40,7 +40,15 @@ fn format_model(model: Option<&rein::ast::ValueExpr>) -> String {
 }
 
 fn format_budget(budget: &rein::ast::Budget) -> String {
-    format!("{}{} per {}", budget.currency, budget.amount, budget.unit)
+    let symbol = match budget.currency.as_str() {
+        "EUR" => "€",
+        "GBP" => "£",
+        "JPY" => "¥",
+        _ => "$",
+    };
+    let dollars = budget.amount / 100;
+    let cents = budget.amount % 100;
+    format!("{symbol}{dollars}.{cents:02} per {}", budget.unit)
 }
 
 fn explain_agents(file: &rein::ast::ReinFile) {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,7 +1,12 @@
 use std::fs;
 use std::path::Path;
 
-const EXAMPLE_REIN: &str = r"// My first Rein agent
+const EXAMPLE_REIN: &str = r#"// My first Rein agent
+
+provider openai {
+    model: "gpt-4o"
+    key: env("OPENAI_API_KEY")
+}
 
 agent assistant {
     model: openai
@@ -17,7 +22,7 @@ agent assistant {
 
     budget: $0.10 per request
 }
-";
+"#;
 
 const ENV_TEMPLATE: &str = r"# Rein environment configuration
 # OPENAI_API_KEY=sk-...


### PR DESCRIPTION
## Changes

- **`rein explain` budget fix**: `format_budget()` was printing raw cents with currency code (e.g. `USD10` for $0.10). Now correctly converts cents → dollars with currency symbol (`$0.10`).
- **`rein init` template**: Added `provider openai { ... }` block to the scaffold so new users see the correct `key: env("...")` syntax from day one.

## QA
- 649 tests pass
- clippy clean
- Verified: `rein explain`, `rein init`, `rein validate` all produce correct output