### PR TITLE
feat(policy): wire PolicyEngine into AgentEngine (#302)

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -91,7 +91,7 @@ pub fn run_agent(
         engine = engine.with_circuit_breaker(cb);
     }
 
-    // Log policy tier if defined.
+    // Attach policy engine if defined.
     if let Some(policy_def) = file.policies.first() {
         let policy = rein::runtime::policy::PolicyEngine::from_def(policy_def);
         eprintln!(
@@ -99,6 +99,7 @@ pub fn run_agent(
             policy.current_tier(),
             policy.tier_count()
         );
+        engine = engine.with_policy(policy);
     }
 
     // If the file has workflows, run the first workflow instead of single-agent execution.

--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -6,6 +6,7 @@ use super::executor::ToolExecutor;
 use super::guardrails::GuardrailEngine;
 use super::interceptor::{InterceptResult, ToolInterceptor};
 use super::permissions::ToolRegistry;
+use super::policy::PolicyEngine;
 use super::provider::{Message, Provider, ToolCallRequest, ToolDef};
 use super::{RunError, RunEvent, RunTrace, ToolCall};
 
@@ -102,6 +103,7 @@ pub struct AgentEngine<'a> {
     stream: Box<dyn StreamCallback + 'a>,
     guardrails: GuardrailEngine,
     circuit_breaker: Option<Mutex<CircuitBreaker>>,
+    policy_engine: Option<Mutex<PolicyEngine>>,
 }
 
 impl<'a> AgentEngine<'a> {
@@ -123,6 +125,7 @@ impl<'a> AgentEngine<'a> {
             stream: Box::new(NoopStream),
             guardrails: GuardrailEngine::empty(),
             circuit_breaker: None,
+            policy_engine: None,
         }
     }
 
@@ -144,6 +147,13 @@ impl<'a> AgentEngine<'a> {
     #[must_use]
     pub fn with_circuit_breaker(mut self, cb: CircuitBreaker) -> Self {
         self.circuit_breaker = Some(Mutex::new(cb));
+        self
+    }
+
+    /// Attach a policy engine for tier-based promotion tracking.
+    #[must_use]
+    pub fn with_policy(mut self, policy: PolicyEngine) -> Self {
+        self.policy_engine = Some(Mutex::new(policy));
         self
     }
 
@@ -217,6 +227,8 @@ impl<'a> AgentEngine<'a> {
 
             self.check_budget(&mut state, cost)?;
 
+            self.evaluate_policy(&mut state);
+
             // Apply guardrails to LLM output.
             let content = if self.guardrails.is_empty() {
                 response.content.clone()
@@ -273,6 +285,25 @@ impl<'a> AgentEngine<'a> {
             });
         }
         Ok(())
+    }
+
+    /// Evaluate policy promotion conditions after a turn and emit events.
+    fn evaluate_policy(&self, state: &mut RunState) {
+        let Some(ref policy_mutex) = self.policy_engine else {
+            return;
+        };
+        let mut policy = policy_mutex.lock().expect("policy engine lock");
+        #[allow(clippy::cast_precision_loss)]
+        let metrics = vec![
+            ("tokens".to_string(), state.total_tokens as f64),
+            ("cost".to_string(), state.total_cost_cents as f64),
+        ];
+        if let Some(ev) = policy.evaluate_promotion(&metrics) {
+            state.events.push(RunEvent::PolicyPromotion {
+                from_tier: ev.from_tier,
+                to_tier: ev.to_tier,
+            });
+        }
     }
 
     /// Process all tool calls from an LLM response.

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::ast::ValueExpr;
 use crate::ast::{AgentDef, Capability, Span};
 use crate::runtime::executor::MockExecutor;
+use crate::runtime::policy::PolicyEngine;
 use crate::runtime::provider::{ChatResponse, MockProvider, ToolCallRequest, ToolDef, Usage};
 
 fn make_agent(
@@ -334,4 +335,111 @@ async fn stream_callback_receives_text() {
     assert_eq!(texts.lock().unwrap().len(), 1);
     assert_eq!(texts.lock().unwrap()[0], "Hello streamed!");
     assert!(*completed.lock().unwrap());
+}
+
+// --- #302 PolicyEngine Tests ---
+
+fn make_policy_engine_with_threshold(metric: &str, threshold: f64) -> PolicyEngine {
+    use crate::ast::{CompareOp, PolicyDef, PolicyTier, Span, WhenComparison, WhenExpr, WhenValue};
+    let tier_supervised = PolicyTier {
+        name: "supervised".to_string(),
+        promote_when: Some(WhenExpr::Comparison(WhenComparison {
+            field: metric.to_string(),
+            op: CompareOp::Gt,
+            value: WhenValue::Number(threshold.to_string()),
+        })),
+        span: Span { start: 0, end: 1 },
+    };
+    let tier_autonomous = PolicyTier {
+        name: "autonomous".to_string(),
+        promote_when: None,
+        span: Span { start: 0, end: 1 },
+    };
+    let def = PolicyDef {
+        tiers: vec![tier_supervised, tier_autonomous],
+        span: Span { start: 0, end: 1 },
+    };
+    PolicyEngine::from_def(&def)
+}
+
+#[tokio::test]
+async fn engine_with_policy_starts_at_first_tier() {
+    let provider = MockProvider::new();
+    provider.push_response(simple_response("done"));
+    let executor = MockExecutor::new();
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let policy = make_policy_engine_with_threshold("tokens", 999_999.0);
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    )
+    .with_policy(policy);
+    let result = engine.run("hi").await.unwrap();
+    assert_eq!(result.response, "done");
+    // No promotion at low token counts — no PolicyPromotion event
+    assert!(
+        !result
+            .trace
+            .events
+            .iter()
+            .any(|e| matches!(e, RunEvent::PolicyPromotion { .. }))
+    );
+}
+
+#[tokio::test]
+async fn engine_with_policy_emits_promotion_event_when_threshold_met() {
+    let provider = MockProvider::new();
+    // One turn, costs ~150 tokens (100 input + 50 output per simple_response)
+    provider.push_response(simple_response("done"));
+    let executor = MockExecutor::new();
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    // Threshold of 1 token — will promote immediately after first LLM call
+    let policy = make_policy_engine_with_threshold("tokens", 1.0);
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    )
+    .with_policy(policy);
+    let result = engine.run("hi").await.unwrap();
+    assert_eq!(result.response, "done");
+    let promoted = result.trace.events.iter().any(|e| {
+        matches!(e, RunEvent::PolicyPromotion { from_tier, to_tier }
+            if from_tier == "supervised" && to_tier == "autonomous")
+    });
+    assert!(promoted, "expected PolicyPromotion event");
+}
+
+#[tokio::test]
+async fn engine_without_policy_has_no_promotion_events() {
+    let provider = MockProvider::new();
+    provider.push_response(simple_response("done"));
+    let executor = MockExecutor::new();
+    let agent = make_agent(vec![], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![],
+        RunConfig::default(),
+    );
+    let result = engine.run("hi").await.unwrap();
+    assert!(
+        !result
+            .trace
+            .events
+            .iter()
+            .any(|e| matches!(e, RunEvent::PolicyPromotion { .. }))
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `policy_engine: Option<Mutex<PolicyEngine>>` field to `AgentEngine`
- Adds `with_policy()` builder method
- Evaluates tier promotion after each LLM turn using `tokens` + `cost` metrics
- Emits `RunEvent::PolicyPromotion` when threshold conditions are met
- Wires `PolicyEngine::from_def()` from `file.policies.first()` in `commands/run.rs`

## Test plan
- [x] Red tests written first (TDD)
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)