### PR TITLE
feat(dag): implement depends_on DAG resolution for workflow steps (#303)

### DIFF
--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -74,6 +74,8 @@ pub enum WorkflowError {
     ApprovalRejected { step: String, reason: String },
     /// A step's approval gate timed out.
     ApprovalTimedOut { step: String },
+    /// A cyclic dependency was detected in step `depends_on` declarations.
+    CyclicDependency(String),
 }
 
 impl std::fmt::Display for WorkflowError {
@@ -91,6 +93,9 @@ impl std::fmt::Display for WorkflowError {
             }
             Self::ApprovalTimedOut { step } => {
                 write!(f, "approval timed out for step '{step}'")
+            }
+            Self::CyclicDependency(detail) => {
+                write!(f, "Cycle detected in workflow step dependencies: {detail}")
             }
         }
     }
@@ -257,6 +262,76 @@ pub async fn run_parallel(
     Ok(build_result(stage_results, final_output))
 }
 
+/// Resolve step execution order using Kahn's topological sort algorithm.
+///
+/// Steps with no `depends_on` maintain their relative file order.
+/// Returns `Err(WorkflowError::CyclicDependency)` if a cycle is detected.
+pub fn resolve_dag(
+    steps: &[crate::ast::StepDef],
+) -> Result<Vec<&crate::ast::StepDef>, WorkflowError> {
+    use std::collections::HashMap;
+
+    let mut in_degree: HashMap<&str, usize> = HashMap::new();
+    let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for step in steps {
+        in_degree.entry(&step.name).or_insert(0);
+        for dep in &step.depends_on {
+            *in_degree.entry(&step.name).or_insert(0) += 1;
+            dependents.entry(dep.as_str()).or_default().push(&step.name);
+        }
+    }
+
+    let mut ready: Vec<&str> = in_degree
+        .iter()
+        .filter(|&(_, &d)| d == 0)
+        .map(|(&name, _)| name)
+        .collect();
+
+    // Stable sort: steps with no deps preserve file order
+    let step_index: HashMap<&str, usize> = steps
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.name.as_str(), i))
+        .collect();
+    ready.sort_by_key(|name| step_index.get(name).copied().unwrap_or(usize::MAX));
+
+    let step_by_name: HashMap<&str, &crate::ast::StepDef> =
+        steps.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    let mut order: Vec<&crate::ast::StepDef> = Vec::new();
+    let mut i = 0;
+
+    while i < ready.len() {
+        let name = ready[i];
+        i += 1;
+        if let Some(step) = step_by_name.get(name) {
+            order.push(step);
+        }
+        if let Some(deps) = dependents.get(name) {
+            let mut newly_ready: Vec<&str> = deps
+                .iter()
+                .filter(|&&dep| {
+                    let d = in_degree.get_mut(dep).unwrap();
+                    *d -= 1;
+                    *d == 0
+                })
+                .copied()
+                .collect();
+            newly_ready.sort_by_key(|name| step_index.get(name).copied().unwrap_or(usize::MAX));
+            ready.extend(newly_ready);
+        }
+    }
+
+    if order.len() != steps.len() {
+        return Err(WorkflowError::CyclicDependency(
+            "one or more steps form a dependency cycle".to_string(),
+        ));
+    }
+
+    Ok(order)
+}
+
 /// Execute a single step definition, running its referenced agent with the
 /// step's goal as additional context.
 ///
@@ -299,20 +374,39 @@ pub async fn run_step(
     run_stage(&step.name, &step.agent, &effective_input, ctx).await
 }
 
-/// Execute all step blocks in a workflow sequentially, chaining outputs.
+/// Execute all step blocks in a workflow, resolving `depends_on` ordering.
+///
+/// Steps are executed in topological order. Each step receives the concatenated
+/// outputs of its declared dependencies as input context.
 ///
 /// # Errors
-/// Returns `WorkflowError` if any step fails.
+/// Returns `WorkflowError` if any step fails or a dependency cycle is detected.
 pub async fn run_steps(
     workflow: &WorkflowDef,
     ctx: &WorkflowContext<'_>,
 ) -> Result<Vec<StageResult>, WorkflowError> {
-    let mut results = Vec::new();
-    let mut current_input = format!("Trigger: {}", workflow.trigger);
+    use std::collections::HashMap;
 
-    for step in &workflow.steps {
-        let result = run_step(step, &current_input, ctx).await?;
-        current_input.clone_from(&result.output);
+    let ordered = resolve_dag(&workflow.steps)?;
+    let trigger_input = format!("Trigger: {}", workflow.trigger);
+
+    let mut outputs: HashMap<String, String> = HashMap::new();
+    let mut results = Vec::new();
+
+    for step in ordered {
+        let input = if step.depends_on.is_empty() {
+            trigger_input.clone()
+        } else {
+            step.depends_on
+                .iter()
+                .filter_map(|dep| outputs.get(dep))
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        let result = run_step(step, &input, ctx).await?;
+        outputs.insert(step.name.clone(), result.output.clone());
         results.push(result);
     }
 

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ast::{ConditionMatcher, ExecutionMode, RouteRule, Span, Stage, WorkflowDef};
+use crate::ast::{ConditionMatcher, ExecutionMode, RouteRule, Span, Stage, StepDef, WorkflowDef};
 use crate::runtime::executor::MockExecutor;
 use crate::runtime::provider::{ChatResponse, MockProvider, Usage};
 use tempfile::NamedTempFile;
@@ -1191,4 +1191,129 @@ async fn step_without_approval_def_skips_handler() {
 
     let result = run_workflow(&workflow, &ctx).await.unwrap();
     assert_eq!(result.final_output, "Done without approval");
+}
+
+// --- #303 DAG depends_on Tests ---
+
+fn make_step(name: &str, agent: &str, depends_on: Vec<&str>) -> StepDef {
+    StepDef {
+        name: name.to_string(),
+        agent: agent.to_string(),
+        goal: None,
+        input: None,
+        output_constraints: vec![],
+        depends_on: depends_on.into_iter().map(str::to_string).collect(),
+        when: None,
+        on_failure: None,
+        send_to: None,
+        fallback: None,
+        for_each: None,
+        typed_input: None,
+        typed_outputs: vec![],
+        escalate: None,
+        approval: None,
+        span: Span::new(0, 1),
+    }
+}
+
+#[test]
+fn dag_no_deps_preserves_file_order() {
+    let steps = vec![make_step("a", "bot", vec![]), make_step("b", "bot", vec![])];
+    let order = resolve_dag(&steps).expect("no cycle");
+    let names: Vec<&str> = order.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["a", "b"]);
+}
+
+#[test]
+fn dag_single_dependency_reorders() {
+    // b depends on a — even if b comes first in file order, a must execute first
+    let steps = vec![
+        make_step("b", "bot", vec!["a"]),
+        make_step("a", "bot", vec![]),
+    ];
+    let order = resolve_dag(&steps).expect("no cycle");
+    let names: Vec<&str> = order.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names[0], "a", "a must come before b");
+    assert_eq!(names[1], "b");
+}
+
+#[test]
+fn dag_diamond_dependency_valid() {
+    // a → b, a → c, b → d, c → d
+    let steps = vec![
+        make_step("a", "bot", vec![]),
+        make_step("b", "bot", vec!["a"]),
+        make_step("c", "bot", vec!["a"]),
+        make_step("d", "bot", vec!["b", "c"]),
+    ];
+    let order = resolve_dag(&steps).expect("no cycle");
+    let names: Vec<&str> = order.iter().map(|s| s.name.as_str()).collect();
+    // a must come first, d must come last
+    assert_eq!(names[0], "a");
+    assert_eq!(names[names.len() - 1], "d");
+    // b and c must appear before d
+    let d_idx = names.iter().position(|&n| n == "d").unwrap();
+    let b_idx = names.iter().position(|&n| n == "b").unwrap();
+    let c_idx = names.iter().position(|&n| n == "c").unwrap();
+    assert!(b_idx < d_idx);
+    assert!(c_idx < d_idx);
+}
+
+#[test]
+fn dag_cycle_returns_error() {
+    // a → b → a forms a cycle
+    let steps = vec![
+        make_step("a", "bot", vec!["b"]),
+        make_step("b", "bot", vec!["a"]),
+    ];
+    let err = resolve_dag(&steps).unwrap_err();
+    assert!(
+        err.to_string().contains("cycle") || err.to_string().contains("Cycle"),
+        "error should mention cycle: {err}"
+    );
+}
+
+#[tokio::test]
+async fn workflow_steps_respect_depends_on_order() {
+    // Steps declared out of order: b depends on a
+    let file = parse_file(
+        r#"
+        agent bot { model: openai }
+    "#,
+    );
+    let workflow = WorkflowDef {
+        name: "dag_wf".to_string(),
+        trigger: "start".to_string(),
+        stages: vec![],
+        steps: vec![
+            make_step("b", "bot", vec!["a"]),
+            make_step("a", "bot", vec![]),
+        ],
+        route_blocks: vec![],
+        parallel_blocks: vec![],
+        auto_resolve: None,
+        within_blocks: vec![],
+        mode: ExecutionMode::Sequential,
+        schedule: None,
+        span: Span::new(0, 1),
+    };
+
+    let provider = MockProvider::new();
+    let executor = MockExecutor::new();
+    let ctx = WorkflowContext {
+        file: &file,
+        provider: &provider,
+        executor: &executor,
+        tool_defs: &[],
+        config: &RunConfig::default(),
+        approval_handler: None,
+    };
+
+    // a runs first, b runs second
+    provider.push_response(simple_response("output from a"));
+    provider.push_response(simple_response("output from b"));
+
+    let result = run_workflow(&workflow, &ctx).await.unwrap();
+    assert_eq!(result.stage_results.len(), 2);
+    assert_eq!(result.final_output, "output from b");
 }


### PR DESCRIPTION
## Summary
- Adds `resolve_dag()` using Kahn's topological sort algorithm
- Steps with no `depends_on` preserve their file order; deps resolved transitively
- Outputs of dependency steps are concatenated and passed as context to dependent steps
- Adds `WorkflowError::CyclicDependency` variant with Display impl
- Updates `run_steps()` to use DAG ordering instead of flat file order

## Test plan
- [x] Red tests written first (TDD)
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Diamond dependency, single dependency, cycle detection, and integration tests
- [x] No regressions

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)