### PR TITLE
feat(engine): RunComplete in cost filter + secrets forwarding integration test (#330, #335)

### DIFF
--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -527,7 +527,7 @@ impl<'a> AgentEngine<'a> {
 /// Returns `true` if the event contributes to any of the requested metric categories.
 ///
 /// Metric names:
-/// - `"cost"` → `LlmCall`, `BudgetUpdate`
+/// - `"cost"` → `LlmCall`, `BudgetUpdate`, `RunComplete`
 /// - `"tool_calls"` → `ToolCallAttempt`, `ToolCallResult`
 /// - `"latency"` → `LlmCall`
 /// - `"guardrails"` → `GuardrailTriggered`

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use serde_json::json;
 
@@ -699,10 +700,12 @@ fn event_matches_unknown_metric_returns_false() {
 }
 
 #[test]
-fn event_matches_unmapped_variants_always_return_false() {
-    // Variants not mapped to any metric must return false for all known metric names
-    // to avoid leaking internal events into filtered OTEL exports.
-    // Note: RunComplete IS mapped to "cost" — tested separately below.
+// Covers variants that are intentionally NOT mapped to any metric category.
+// These events must return false for every known metric name to prevent
+// internal runtime events from leaking into filtered OTEL exports.
+// Note: RunComplete IS mapped to "cost" and is excluded from this test —
+// it is covered by `run_complete_matches_cost_metric` below.
+fn unmapped_variants_return_false_for_all_known_metrics() {
     let all_metrics = ["cost", "tool_calls", "latency", "guardrails"];
     let cb = RunEvent::CircuitBreakerTripped {
         name: "cb".to_string(),
@@ -733,8 +736,6 @@ fn run_complete_matches_cost_metric() {
 
 // #335: Verify secrets injected via with_secrets() reach executor.execute() ctx.
 // Uses a SecretCapturingExecutor that records the last secrets map seen.
-use std::sync::Mutex;
-
 struct SecretCapturingExecutor {
     captured: Mutex<Option<HashMap<String, String>>>,
     response: String,


### PR DESCRIPTION
## Summary
- **#330**: `RunComplete` added to the `"cost"` arm of `event_matches_metrics` — the final run summary event (carrying `total_cost_cents` + `total_tokens`) is now included when exporting with `metrics: ["cost"]`
- **#335**: Engine-level integration test with `SecretCapturingExecutor` verifies that secrets injected via `engine.with_secrets()` reach `execute()` as a non-empty `ctx.secrets` map through the full run loop

## Test plan
- [x] Red test written first for #330 (`run_complete_matches_cost_metric`)
- [x] #335 test green immediately — secrets forwarding already wired from #320
- [x] All tests green: `cargo test --all-targets` (719 tests)
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Formatting clean: `cargo fmt --check`
- [x] No regressions

Closes #330
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)