### PR TITLE
fix(otel): warn on completed_at parse failure + test fallback paths (#343, #344)

### DIFF
--- a/src/runtime/otel_export/mod.rs
+++ b/src/runtime/otel_export/mod.rs
@@ -111,7 +111,7 @@ fn pseudo_id(seed: u64, len: usize) -> String {
 
 /// Parse an RFC 3339 timestamp string and return nanoseconds since Unix epoch,
 /// or `None` if the string cannot be parsed or represents a pre-epoch time.
-fn try_rfc3339_to_unix_nanos(ts: &str) -> Option<u64> {
+pub(crate) fn try_rfc3339_to_unix_nanos(ts: &str) -> Option<u64> {
     use chrono::DateTime;
     DateTime::parse_from_rfc3339(ts)
         .ok()

--- a/src/runtime/otel_export/tests.rs
+++ b/src/runtime/otel_export/tests.rs
@@ -150,15 +150,13 @@ fn pre_epoch_started_at_falls_back_to_epoch_zero() {
 // This is tested indirectly: the fallback produces a non-zero end_ns equal to start + duration.
 #[test]
 fn invalid_completed_at_falls_back_to_start_plus_duration() {
-    // started_at = 2026-01-01T00:00:00Z = 1_767_225_600_000_000_000 ns
-    let start_ns: u64 = 1_767_225_600 * 1_000_000_000;
+    let started_at = "2026-01-01T00:00:00Z";
+    // Derive start_ns from the same helper to keep the test self-consistent.
+    let start_ns: u64 =
+        try_rfc3339_to_unix_nanos(started_at).expect("test timestamp must be valid RFC 3339");
     let duration_ms: u64 = 2_000;
-    let trace = RunTrace { events: vec![] }.to_structured(
-        "agent",
-        "2026-01-01T00:00:00Z",
-        "not-a-date",
-        duration_ms,
-    );
+    let trace =
+        RunTrace { events: vec![] }.to_structured("agent", started_at, "not-a-date", duration_ms);
     let root = &to_otlp(&trace).scope_spans[0].spans[0];
     assert_eq!(
         root.end_time_unix_nano,


### PR DESCRIPTION
## Summary
- **#343**: Add tests proving `rfc3339_to_unix_nanos` falls back to `0` for invalid strings and pre-epoch timestamps (tests: `invalid_started_at_falls_back_to_epoch_zero`, `pre_epoch_started_at_falls_back_to_epoch_zero`)
- **#344**: Emit `rein[otel]: warning:` when `completed_at` fails to parse, matching parity with the `started_at` warning path (test: `invalid_completed_at_falls_back_to_start_plus_duration`)
- **bugfix**: Update `SecretCapturingExecutor` in `engine/tests.rs` to store `Secrets` instead of `HashMap<String, String>` — fixes compilation regression from PR #341

## Test plan
- [ ] `invalid_started_at_falls_back_to_epoch_zero` passes
- [ ] `pre_epoch_started_at_falls_back_to_epoch_zero` passes
- [ ] `invalid_completed_at_falls_back_to_start_plus_duration` passes
- [ ] All tests green: `cargo test --all-targets`
- [ ] Clippy clean: `cargo clippy -- -D warnings`

Closes #343
Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)