### PR TITLE
fix(engine): enforce monetary caps declared in  (P0 #349)

### DIFF
--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -349,42 +349,48 @@ impl<'a> AgentEngine<'a> {
 
     /// Process all tool calls from an LLM response.
     ///
-    /// `turn_cost` is the LLM cost (cents) for this turn and is attributed to
-    /// each capped tool that executes in this turn. Caps are checked BEFORE
-    /// execution: if a tool's accumulated attributed cost has already reached
-    /// its declared cap, the call is denied and the agent is informed.
+    /// `turn_cost` is the LLM cost (cents) for this turn. Each capped tool that
+    /// is **allowed to execute** (i.e., has not yet reached its cap) gets an equal
+    /// share of `turn_cost` attributed to it. Intercept results are computed once
+    /// per tool call and reused for both cap-checking and dispatch.
     async fn process_tool_calls(
         &self,
         state: &mut RunState,
         tool_calls: &[ToolCallRequest],
         turn_cost: u64,
     ) {
-        // Count capped tools in this batch to distribute turn_cost evenly.
-        let capped_count = tool_calls
+        // Single pass: resolve every tool call and its intercept result.
+        let resolved: Vec<(&ToolCallRequest, ToolCall, InterceptResult)> = tool_calls
             .iter()
-            .filter(|tc| {
-                let tool = ToolCall {
-                    namespace: Self::extract_namespace(&tc.name),
-                    action: Self::extract_action(&tc.name),
-                    arguments: serde_json::Value::Null,
+            .map(|tc_req| {
+                let tool_call = ToolCall {
+                    namespace: Self::extract_namespace(&tc_req.name),
+                    action: Self::extract_action(&tc_req.name),
+                    arguments: tc_req.arguments.clone(),
                 };
-                matches!(
-                    self.interceptor.intercept(&tool),
-                    InterceptResult::CappedAt { .. }
-                )
+                let intercept = self.interceptor.intercept(&tool_call);
+                (tc_req, tool_call, intercept)
+            })
+            .collect();
+
+        // Count capped tools that are within their cap and will actually execute.
+        // Denied-by-cap tools are excluded so cost is not under-attributed to
+        // the tools that do execute.
+        let executing_capped_count = resolved
+            .iter()
+            .filter(|(_, tool_call, intercept)| {
+                if let InterceptResult::CappedAt { max_cents, .. } = intercept {
+                    let key = format!("{}.{}", tool_call.namespace, tool_call.action);
+                    let spent = state.per_tool_spent.get(&key).copied().unwrap_or(0);
+                    spent < *max_cents
+                } else {
+                    false
+                }
             })
             .count()
             .max(1) as u64;
 
-        for tc_req in tool_calls {
-            let tool_call = ToolCall {
-                namespace: Self::extract_namespace(&tc_req.name),
-                action: Self::extract_action(&tc_req.name),
-                arguments: tc_req.arguments.clone(),
-            };
-
-            let intercept = self.interceptor.intercept(&tool_call);
-
+        for (tc_req, tool_call, intercept) in resolved {
             match intercept {
                 InterceptResult::Allowed => {
                     self.execute_allowed_tool(state, &tc_req.id, tool_call)
@@ -407,9 +413,10 @@ impl<'a> AgentEngine<'a> {
                             .messages
                             .push(Message::tool(&tc_req.id, format!("Permission denied: {reason}")));
                     } else {
-                        // Attribute this turn's LLM cost (divided evenly across capped tools).
+                        // Attribute this turn's LLM cost evenly across capped tools
+                        // that are actually executing (not already over-cap).
                         *state.per_tool_spent.entry(key).or_insert(0) +=
-                            turn_cost / capped_count;
+                            turn_cost / executing_capped_count;
                         self.execute_allowed_tool(state, &tc_req.id, tool_call)
                             .await;
                     }

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -817,18 +817,23 @@ fn capped_cap(ns: &str, action: &str, max_cents: u64) -> Capability {
     }
 }
 
-// When cumulative LLM cost attributed to a capped tool exceeds the cap,
+// When cumulative LLM cost attributed to a capped tool reaches the cap,
 // further calls to that tool must be denied.
 #[tokio::test]
 async fn capped_tool_denied_after_cap_exceeded() {
-    // Cap api.call at 1 cent. The mock LLM will cost more than that (150 tokens
-    // at gpt-4o rates) so the second tool call should be denied.
+    // Cap api.call at 1 cent.
+    // Mock LLM cost: 100 input + 50 output = 150 tokens at gpt-4o rates.
+    // gpt-4o pricing: 250¢/M input + 1000¢/M output.
+    // Cost = (100 × 250 + 50 × 1000) / 1_000_000 = 0.075¢ → div_ceil → 1¢.
+    // After Turn 1: per_tool_spent["api.call"] = 1¢ = cap → Turn 2 call is denied.
     let agent = make_agent(vec![capped_cap("api", "call", 1)], vec![], None);
     let registry = ToolRegistry::from_agent(&agent);
     let provider = MockProvider::new();
     let executor = MockExecutor::new();
 
-    // Turn 1: LLM requests api.call → executor responds → LLM gives final answer
+    // Turn 1: tool call allowed (spent 0 < cap 1), cost attributed → spent = 1.
+    // Turn 2: tool call denied (spent 1 >= cap 1), LLM sees denial message.
+    // Turn 3: LLM gives final answer.
     provider.push_response(tool_call_response("api.call", json!({})));
     provider.push_response(tool_call_response("api.call", json!({})));
     provider.push_response(simple_response("done"));
@@ -836,23 +841,21 @@ async fn capped_tool_denied_after_cap_exceeded() {
     let engine = AgentEngine::new(&provider, &executor, &registry, vec![], RunConfig::default());
     let result = engine.run("go").await.expect("should complete");
 
-    let attempts: Vec<_> = result
+    let allowed_count = result
         .trace
         .events
         .iter()
-        .filter(|e| matches!(e, RunEvent::ToolCallAttempt { .. }))
-        .collect();
-
-    // At least one attempt must have been denied (cap exceeded).
-    let denied_count = attempts
+        .filter(|e| matches!(e, RunEvent::ToolCallAttempt { allowed: true, .. }))
+        .count();
+    let denied_count = result
+        .trace
+        .events
         .iter()
         .filter(|e| matches!(e, RunEvent::ToolCallAttempt { allowed: false, .. }))
         .count();
-    assert!(
-        denied_count >= 1,
-        "expected at least one denied call after cap exceeded; trace: {:?}",
-        result.trace.events
-    );
+
+    assert_eq!(allowed_count, 1, "exactly one call should be allowed (within cap)");
+    assert_eq!(denied_count, 1, "exactly one call should be denied (cap reached)");
 }
 
 // A tool with a generous cap should be allowed as long as cost stays under it.


### PR DESCRIPTION
## Summary
- `CappedAt` intercept result was previously treated identically to `Allowed` — cap constraints were parsed but never enforced at runtime
- Adds `per_tool_spent: HashMap<String, u64>` to `RunState` to track accumulated LLM cost per capped tool
- Before executing a capped tool, accumulated cost is compared against declared cap; calls are denied with a clear reason if exceeded
- LLM turn cost is distributed evenly across all capped tools in the same batch
- Tools within their cap continue to execute normally (no regression)

## Attribution model
Since tool calls themselves don't have intrinsic cost in the current model (cost comes from LLM calls), the LLM turn cost is attributed to capped tools. This correctly limits agent behavior: once the LLM has spent more on turns involving a capped tool than the cap allows, further calls are denied.

## Test plan
- [x] Red tests written first: `capped_tool_denied_after_cap_exceeded`, `capped_tool_allowed_within_cap`
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions in existing engine tests

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)