### PR TITLE
fix(validate): 'Valid (with warnings)' to stderr (#354)

### DIFF
--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -149,7 +149,9 @@ pub fn run_validate(path: &std::path::Path, dump_ast: bool, format: &str, strict
             if diags.is_empty() {
                 println!("✓ Valid");
             } else {
-                println!("✓ Valid (with warnings)");
+                // Warnings are diagnostic output — emit to stderr so stdout stays
+                // clean for piping and scripting.
+                eprintln!("✓ Valid (with warnings)");
             }
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -182,6 +182,30 @@ fn eval_missing_file_exits_one() {
     assert_eq!(status.code(), Some(1), "expected exit 1 for missing file");
 }
 
+// #354: "Valid (with warnings)" must appear on stderr, not stdout.
+#[test]
+fn valid_with_warnings_on_stderr_not_stdout() {
+    let out = Command::new(rein_bin())
+        .args([
+            "validate",
+            "--strict",
+            example("eval_scenarios.rein").to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn rein");
+    assert!(out.status.success(), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("with warnings"),
+        "'Valid (with warnings)' must not appear on stdout; stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("with warnings"),
+        "'Valid (with warnings)' must appear on stderr; stderr: {stderr}"
+    );
+}
+
 #[test]
 fn eval_scenario_filter_unknown_exits_zero() {
     let out = Command::new(rein_bin())


### PR DESCRIPTION
## Summary
- `✓ Valid (with warnings)` was printed to stdout while the warning diagnostics were on stderr
- A caller redirecting stdout would see a misleading clean output, not realizing warnings existed
- Now the status message goes to stderr alongside the warnings
- `✓ Valid` (no warnings) remains on stdout for clean piping

## Test plan
- [x] Red test first: `valid_with_warnings_on_stderr_not_stdout` in `tests/cli.rs`
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)