### PR TITLE
fix: misc API hardening batch (#431, #462, #470, #471, #472)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ module_name_repetitions = "allow"
 tempfile = "3.25.0"
 wiremock = "0.6.5"
 serial_test = "3.2.0"
-tokio = { version = "1.49.0", features = ["test-util"] }
+tokio = { version = "1", features = ["test-util"] }

--- a/src/runtime/approval/mod.rs
+++ b/src/runtime/approval/mod.rs
@@ -305,9 +305,14 @@ impl AuditingApprovalHandler {
     }
 
     /// Attach a workflow name to every audit entry emitted by this handler.
+    ///
+    /// Empty strings are silently ignored; the workflow field will remain `None`.
     #[must_use]
     pub fn with_workflow(mut self, name: impl Into<String>) -> Self {
-        self.workflow_name = Some(name.into());
+        let name = name.into();
+        if !name.is_empty() {
+            self.workflow_name = Some(name);
+        }
         self
     }
 
@@ -393,8 +398,8 @@ impl ApprovalHandler for AuditingApprovalHandler {
         };
         // Capture the rejection reason if present so the audit record can
         // reconstruct _why_ an approval was rejected (not just that it was).
-        let rejection_reason = match &status {
-            ApprovalStatus::Rejected { reason } => Some(reason.as_str()),
+        let rejection_reason: Option<String> = match &status {
+            ApprovalStatus::Rejected { reason } => Some(reason.clone()),
             _ => None,
         };
 
@@ -414,7 +419,7 @@ impl ApprovalHandler for AuditingApprovalHandler {
         // Only include "reason" for rejected decisions; omitting the key for
         // approved/timed-out outcomes avoids a noisy `null` in audit records.
         if let Some(r) = rejection_reason {
-            meta["reason"] = serde_json::Value::String(r.to_string());
+            meta["reason"] = serde_json::Value::String(r);
         }
         // Include "original_status" only when it diverges from "decision" —
         // i.e., when the handler returned Pending but the compliance field

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -9,6 +9,7 @@ use crate::ast::{ExecutionMode, ReinFile, RouteRule, Stage, WorkflowDef};
 /// as the single, canonical predicate; inspect `status` directly only when you need
 /// to distinguish `Failed` from `Skipped`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StageResultStatus {
     /// The step ran to completion (agent produced a response).
     Executed,

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -2591,7 +2591,7 @@ async fn independent_step_runs_even_if_sibling_fails() {
     // step_b (bot) runs successfully
     provider.push_response(simple_response("step_b_output"));
 
-    let (results, _events) = run_steps(&workflow, &ctx)
+    let (results, events) = run_steps(&workflow, &ctx)
         .await
         .expect("run_steps must not abort when only independent step fails");
 
@@ -2604,6 +2604,13 @@ async fn independent_step_runs_even_if_sibling_fails() {
         step_a_result.status,
         StageResultStatus::Failed,
         "failed step must have status Failed; results: {results:?}"
+    );
+    // A StepFailed event must be emitted — this is the trigger condition for the scenario.
+    assert!(
+        events.iter().any(
+            |e| matches!(e, crate::runtime::RunEvent::StepFailed { step, .. } if step == "step_a")
+        ),
+        "expected StepFailed event for step_a; events: {events:?}"
     );
     // step_b should have produced output
     let step_b_result = results


### PR DESCRIPTION
## Summary
- **#431**: Relax tokio dev-dep from `"1.49.0"` exact pin to `"1"` range (matches `[dependencies]` entry, avoids resolver conflicts)
- **#462**: `with_workflow()` now silently ignores empty strings — prevents `workflow: Some("")` in audit records
- **#470**: `independent_step_runs_even_if_sibling_fails` test now asserts the `StepFailed` event for `step_a` (the trigger condition for the independence invariant)
- **#471**: `StageResultStatus` is `#[non_exhaustive]` — adding future variants (e.g. `TimedOut`) won't be a semver break
- **#472**: `rejection_reason` clones the string instead of borrowing from `status`, removing a fragile lifetime coupling

## Test plan
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Fmt clean: `cargo fmt --check`
- [x] No regressions

Closes #431, #462, #470, #471, #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)