### PR TITLE
fix: remove debug_assert and rename failed_dependency to blocked_dependency (#467, #468)

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -271,18 +271,9 @@ fn run_workflow_mode(
                 );
             }
             eprintln!("Duration: {duration:.2?}");
-            // Skips only occur as cascades from upstream failures under current
-            // semantics — a skipped step implies at least one failed step.
-            // The assert makes this invariant machine-checked so a future change
-            // (e.g., when:-condition skips tracked in #461) cannot silently
-            // produce a wrong exit code. When #461 lands, remove this assert
-            // and update the exit-code table in docs/getting-started.md.
-            debug_assert!(
-                failed_count > 0 || skipped_count == 0,
-                "skipped_count={skipped_count} but failed_count=0: skips must cascade from a failure (see #461)"
-            );
             // Exit 0: all steps succeeded.
-            // Exit 1: partial success — step(s) failed or were cascade-skipped.
+            // Exit 1: partial success — step(s) failed, were cascade-skipped, or
+            //         were conditionally skipped via when: (#455).
             // Exit 2: hard abort — see Err arm below.
             i32::from(failed_count > 0 || skipped_count > 0)
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -136,9 +136,11 @@ pub enum RunEvent {
     StepSkipped {
         /// Name of the step that was skipped.
         step: String,
-        /// Name of the dependency step that caused this step to be skipped.
-        /// Enables structured OTEL queries like `rein.step.failed_dependency = "step_a"`.
-        failed_dependency: String,
+        /// Name of the immediate dependency that blocked this step. May itself be a
+        /// skipped step rather than a directly failed step (transitive chains).
+        /// Use the `StepFailed` event to find the root-cause step.
+        /// Enables structured OTEL queries via `rein.step.blocked_dependency`.
+        blocked_dependency: String,
         /// Human-readable reason (e.g. "dependency '`step_a`' failed").
         reason: String,
     },

--- a/src/runtime/otel_export/mod.rs
+++ b/src/runtime/otel_export/mod.rs
@@ -417,13 +417,13 @@ fn event_to_span_data(event: &super::RunEvent) -> (String, Vec<OtelAttribute>) {
         ),
         RunEvent::StepSkipped {
             step,
-            failed_dependency,
+            blocked_dependency,
             reason,
         } => (
             "rein.step.skipped".to_string(),
             vec![
                 attr_str("rein.step.name", step),
-                attr_str("rein.step.failed_dependency", failed_dependency),
+                attr_str("rein.step.blocked_dependency", blocked_dependency),
                 attr_str("rein.step.reason", reason),
             ],
         ),

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -678,7 +678,7 @@ pub async fn run_steps(
             let reason = format!("dependency '{failed_dep}' failed");
             state.events.push(super::RunEvent::StepSkipped {
                 step: step.name.clone(),
-                failed_dependency: failed_dep.clone(),
+                blocked_dependency: failed_dep.clone(),
                 reason,
             });
             // Insert an empty output so the step appears in `outputs` for

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -2745,7 +2745,7 @@ async fn cyclic_dependency_is_hard_error() {
 
 /// #363/#374 — A `for_each` step that fails (agent not found) is a soft error:
 /// it is recorded as `StepFailed` and its declared dependents receive
-/// `StepSkipped`. The `StepSkipped` event must include `failed_dependency`
+/// `StepSkipped`. The `StepSkipped` event must include `blocked_dependency`
 /// set to the failing step's name (not a generic "unknown").
 #[tokio::test]
 async fn for_each_step_failure_cascades_to_dependent() {
@@ -2789,7 +2789,7 @@ async fn for_each_step_failure_cascades_to_dependent() {
         result.events
     );
 
-    // step_b skipped because step_a failed → StepSkipped with correct failed_dependency.
+    // step_b skipped because step_a failed → StepSkipped with correct blocked_dependency.
     let skipped_b = result.events.iter().find(
         |e| matches!(e, crate::runtime::RunEvent::StepSkipped { step, .. } if step == "step_b"),
     );
@@ -2799,12 +2799,12 @@ async fn for_each_step_failure_cascades_to_dependent() {
         result.events
     );
     if let Some(crate::runtime::RunEvent::StepSkipped {
-        failed_dependency, ..
+        blocked_dependency, ..
     }) = skipped_b
     {
         assert_eq!(
-            failed_dependency, "step_a",
-            "StepSkipped.failed_dependency must be 'step_a'"
+            blocked_dependency, "step_a",
+            "StepSkipped.blocked_dependency must be 'step_a'"
         );
     }
 


### PR DESCRIPTION
## Summary
- **#467**: Remove `debug_assert!(failed_count > 0 || skipped_count == 0)` from `commands/run.rs`. When `when:`-condition skips (#455) land they produce `skipped_count > 0 && failed_count == 0`, which is correct — the assert would fire on valid behavior. Replaced with a comment documenting the full exit-code contract including conditional skips.
- **#468**: Rename `StepSkipped.failed_dependency` → `blocked_dependency` (and OTEL attribute `rein.step.failed_dependency` → `rein.step.blocked_dependency`). The old name implied the referenced step always failed; in transitive skip chains the immediate blocker may itself be a skipped step, not a directly failed one.

## Test plan
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Fmt clean: `cargo fmt --check`
- [x] No regressions

Closes #467, #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)