### PR TITLE
fix: timeout follow-ups — serde skip, workflow hard error, OTEL partial (#424, #425, #426, #427, #430)

### DIFF
--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -128,6 +128,7 @@ mod tests {
                 tool_calls_denied: 0,
                 duration_ms: 1000,
             },
+            is_partial: false,
         }
     }
 

--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -629,19 +629,35 @@ impl<'a> AgentEngine<'a> {
             total_tokens,
             total_cost_cents,
         };
-        self.apply_otel_export(&result, duration);
+        // #430: mark the OTEL export as partial so dashboards can distinguish
+        // timed-out runs from normally-empty completions via rein.run.partial.
+        self.apply_otel_export_with_flags(&result, duration, true);
     }
 
     /// Apply OTEL export after a run completes (side-effect only, never fails loudly).
     fn apply_otel_export(&self, result: &RunResult, duration: std::time::Duration) {
+        self.apply_otel_export_with_flags(result, duration, false);
+    }
+
+    /// Apply OTEL export with an optional `is_partial` flag.
+    ///
+    /// When `is_partial` is `true` (e.g. a timed-out run), the root OTEL span
+    /// will carry `rein.run.partial = "true"` so dashboards can distinguish
+    /// incomplete runs from normally-empty completions.
+    fn apply_otel_export_with_flags(
+        &self,
+        result: &RunResult,
+        duration: std::time::Duration,
+        is_partial: bool,
+    ) {
         let name = self.agent_name.as_deref().unwrap_or("agent");
         match &self.otel_mode {
             OtelMode::None => {}
             OtelMode::FileOnComplete => {
-                Self::export_otel_to_file(result, duration, name);
+                Self::export_otel_to_file(result, duration, name, is_partial);
             }
             OtelMode::StdoutOnComplete { metrics } => {
-                Self::export_otel_to_stdout(result, duration, metrics, name);
+                Self::export_otel_to_stdout(result, duration, metrics, name, is_partial);
             }
         }
     }
@@ -654,22 +670,30 @@ impl<'a> AgentEngine<'a> {
         result: &RunResult,
         duration: std::time::Duration,
         agent_name: &str,
+        is_partial: bool,
     ) -> (super::StructuredTrace, chrono::DateTime<chrono::Utc>) {
         let now = chrono::Utc::now();
         let started =
             now - chrono::Duration::from_std(duration).unwrap_or(chrono::Duration::zero());
-        let trace = result.trace.to_structured(
+        let mut trace = result.trace.to_structured(
             agent_name,
             &started.to_rfc3339(),
             &now.to_rfc3339(),
             duration.as_millis().try_into().unwrap_or(u64::MAX),
         );
+        trace.is_partial = is_partial;
         (trace, now)
     }
 
     /// Write OTLP JSON to a timestamped file.
-    fn export_otel_to_file(result: &RunResult, duration: std::time::Duration, agent_name: &str) {
-        let (structured, completed_at) = Self::build_structured_trace(result, duration, agent_name);
+    fn export_otel_to_file(
+        result: &RunResult,
+        duration: std::time::Duration,
+        agent_name: &str,
+        is_partial: bool,
+    ) {
+        let (structured, completed_at) =
+            Self::build_structured_trace(result, duration, agent_name, is_partial);
         match super::otel_export::to_otlp_json(&structured) {
             Ok(json) => {
                 // Reuse the timestamp captured in build_structured_trace so the
@@ -691,10 +715,11 @@ impl<'a> AgentEngine<'a> {
         duration: std::time::Duration,
         metrics: &[String],
         agent_name: &str,
+        is_partial: bool,
     ) {
         use super::otel_export::to_otlp;
         let (mut structured, _completed_at) =
-            Self::build_structured_trace(result, duration, agent_name);
+            Self::build_structured_trace(result, duration, agent_name, is_partial);
         if !metrics.is_empty() {
             structured
                 .events

--- a/src/runtime/engine/tests.rs
+++ b/src/runtime/engine/tests.rs
@@ -16,6 +16,45 @@ use crate::runtime::provider::{ChatResponse, MockProvider, ToolCallRequest, Tool
 /// `tokio::time::timeout` wrapper so the test finishes instantly.
 struct HangingProvider;
 
+/// A `Provider` that returns a tool-call on the first call, then hangs forever.
+/// Used to test multi-turn timeout scenarios (#424).
+struct HangAfterFirstProvider {
+    calls: std::sync::Mutex<u32>,
+}
+
+impl HangAfterFirstProvider {
+    fn new() -> Self {
+        Self {
+            calls: std::sync::Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::runtime::provider::Provider for HangAfterFirstProvider {
+    fn name(&self) -> &'static str {
+        "hang_after_first"
+    }
+
+    async fn chat(
+        &self,
+        _messages: &[crate::runtime::provider::Message],
+        _tools: &[ToolDef],
+    ) -> Result<ChatResponse, crate::runtime::provider::ProviderError> {
+        let call_num = {
+            let mut guard = self.calls.lock().unwrap();
+            let n = *guard;
+            *guard += 1;
+            n
+        };
+        if call_num == 0 {
+            Ok(tool_call_response("test.noop", serde_json::json!({})))
+        } else {
+            std::future::pending().await
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl crate::runtime::provider::Provider for HangingProvider {
     fn name(&self) -> &'static str {
@@ -1095,5 +1134,58 @@ async fn stage_timeout_records_circuit_breaker_failure() {
         matches!(result2, Err(RunError::CircuitBreakerOpen)),
         "second run should be blocked by open circuit breaker; got: {:?}",
         result2
+    );
+}
+
+// #424: timeout on turn > 0 must carry prior events in partial_trace.
+// Turn 0 succeeds (tool call), turn 1 hangs — partial trace must contain
+// the turn 0 LlmCall event AND the final StageTimeout { turn: 1 } event.
+#[tokio::test(start_paused = true)]
+async fn stage_timeout_on_turn_1_includes_prior_events_in_partial_trace() {
+    let agent = make_agent(vec![cap("test", "noop")], vec![], None);
+    let registry = ToolRegistry::from_agent(&agent);
+    let executor = MockExecutor::new();
+    executor.on_call("test", "noop", "ok");
+
+    let provider = HangAfterFirstProvider::new();
+
+    let engine = AgentEngine::new(
+        &provider,
+        &executor,
+        &registry,
+        vec![ToolDef {
+            name: "test.noop".to_string(),
+            description: "no-op tool".to_string(),
+            parameters: serde_json::json!({}),
+        }],
+        RunConfig {
+            stage_timeout_secs: Some(5),
+            ..RunConfig::default()
+        },
+    );
+
+    let result = engine.run("hello").await;
+    let Err(RunError::Timeout { partial_trace }) = result else {
+        panic!("expected RunError::Timeout; got: {:?}", result);
+    };
+
+    // Must contain turn 0's LlmCall (from the successful first provider call).
+    assert!(
+        partial_trace
+            .events
+            .iter()
+            .any(|e| matches!(e, RunEvent::LlmCall { .. })),
+        "partial_trace must include turn 0 LlmCall; got: {:?}",
+        partial_trace.events
+    );
+
+    // StageTimeout must be the last event, on turn 1.
+    assert!(
+        matches!(
+            partial_trace.events.last(),
+            Some(RunEvent::StageTimeout { turn: 1, .. })
+        ),
+        "last event must be StageTimeout {{ turn: 1, .. }}; got: {:?}",
+        partial_trace.events
     );
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -152,7 +152,7 @@ pub enum RunEvent {
 }
 
 /// An ordered log of all events that occurred during a run.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RunTrace {
     pub events: Vec<RunEvent>,
     /// Real wall-clock offsets (ms from run start) captured at event-push time.
@@ -279,6 +279,7 @@ impl RunTrace {
                 tool_calls_denied: tool_denied,
                 duration_ms,
             },
+            is_partial: false,
         }
     }
 
@@ -476,6 +477,11 @@ pub struct StructuredTrace {
     pub events: Vec<TimestampedEvent>,
     /// Aggregate statistics.
     pub stats: TraceStats,
+    /// `true` when this trace was exported from a partial/timed-out run.
+    /// OTEL consumers can filter on `rein.run.partial = "true"` to distinguish
+    /// incomplete runs from normally-empty completions.
+    #[serde(default)]
+    pub is_partial: bool,
 }
 
 /// An event with a timestamp.
@@ -513,7 +519,11 @@ pub enum RunError {
     /// Provider call exceeded `stage_timeout_secs`. Contains events emitted
     /// up to (and including) the `StageTimeout` event so callers can inspect
     /// the partial trace (e.g. in tests or structured error reporting).
+    ///
+    /// `partial_trace` carries `#[serde(skip)]` — it is in-process only and
+    /// must not appear on the wire. Wire consumers see `{"timeout": {}}`.
     Timeout {
+        #[serde(skip)]
         partial_trace: RunTrace,
     },
 }

--- a/src/runtime/otel_export/mod.rs
+++ b/src/runtime/otel_export/mod.rs
@@ -169,20 +169,27 @@ pub fn to_otlp(trace: &StructuredTrace) -> OtelResourceSpans {
         kind: 1, // INTERNAL
         start_time_unix_nano: start_ns,
         end_time_unix_nano: end_ns,
-        attributes: vec![
-            attr_str("rein.agent.name", &trace.agent),
-            attr_int("rein.tokens.total", trace.stats.total_tokens.cast_signed()),
-            attr_int(
-                "rein.cost.cents",
-                trace.stats.total_cost_cents.cast_signed(),
-            ),
-            attr_int("rein.llm.calls", trace.stats.llm_calls.cast_signed()),
-            attr_int("rein.tool.calls", trace.stats.tool_calls.cast_signed()),
-            attr_int(
-                "rein.tool.denied",
-                trace.stats.tool_calls_denied.cast_signed(),
-            ),
-        ],
+        attributes: {
+            let mut attrs = vec![
+                attr_str("rein.agent.name", &trace.agent),
+                attr_int("rein.tokens.total", trace.stats.total_tokens.cast_signed()),
+                attr_int(
+                    "rein.cost.cents",
+                    trace.stats.total_cost_cents.cast_signed(),
+                ),
+                attr_int("rein.llm.calls", trace.stats.llm_calls.cast_signed()),
+                attr_int("rein.tool.calls", trace.stats.tool_calls.cast_signed()),
+                attr_int(
+                    "rein.tool.denied",
+                    trace.stats.tool_calls_denied.cast_signed(),
+                ),
+            ];
+            // #430: mark partial/timed-out exports so dashboards can filter them.
+            if trace.is_partial {
+                attrs.push(attr_str("rein.run.partial", "true"));
+            }
+            attrs
+        },
         status: OtelStatus {
             code: 1, // OK
             message: None,
@@ -408,7 +415,7 @@ fn event_to_span_data(event: &super::RunEvent) -> (String, Vec<OtelAttribute>) {
         RunEvent::StageTimeout { turn, timeout_secs } => (
             "rein.stage.timeout".to_string(),
             vec![
-                attr_int("rein.stage.turn", i64::try_from(*turn).unwrap_or(-1)),
+                attr_int("rein.stage.turn", i64::try_from(*turn).unwrap_or(i64::MAX)),
                 attr_int(
                     "rein.stage.timeout_secs",
                     i64::try_from(*timeout_secs).unwrap_or(i64::MAX),

--- a/src/runtime/otel_export/tests.rs
+++ b/src/runtime/otel_export/tests.rs
@@ -186,3 +186,85 @@ fn otlp_root_span_has_stats() {
         .unwrap();
     assert_eq!(cost.value.int_value, Some(5));
 }
+
+// #425: rein.stage.turn in StageTimeout span must use i64::MAX as overflow sentinel,
+// consistent with rein.stage.timeout_secs — not -1 which is semantically undefined.
+#[test]
+fn stage_timeout_turn_uses_imax_sentinel_not_minus_one() {
+    use crate::runtime::RunEvent;
+    use crate::runtime::RunTrace;
+
+    let events = vec![RunEvent::StageTimeout {
+        turn: 0,
+        timeout_secs: 5,
+    }];
+    let trace = RunTrace::from_events(events);
+    let structured = trace.to_structured(
+        "test_agent",
+        "2026-01-01T00:00:00Z",
+        "2026-01-01T00:00:01Z",
+        1000,
+    );
+    let resource_spans = to_otlp(&structured);
+    let spans = &resource_spans.scope_spans[0].spans;
+
+    let timeout_span = spans
+        .iter()
+        .find(|s| s.name == "rein.stage.timeout")
+        .expect("must have a rein.stage.timeout span");
+
+    let turn_attr = timeout_span
+        .attributes
+        .iter()
+        .find(|a| a.key == "rein.stage.turn")
+        .expect("must have rein.stage.turn attribute");
+
+    // The value is 0 (valid), so just check it's not -1.
+    assert_ne!(
+        turn_attr.value.int_value,
+        Some(-1),
+        "rein.stage.turn must not use -1 as sentinel; got: {:?}",
+        turn_attr.value
+    );
+    assert_eq!(turn_attr.value.int_value, Some(0));
+}
+
+// #430: export_partial must mark the root span with rein.run.partial = "true"
+// so dashboards can distinguish incomplete runs from normal empty completions.
+#[test]
+fn partial_trace_root_span_has_partial_attribute() {
+    let mut trace = sample_trace();
+    trace.is_partial = true;
+
+    let resource_spans = to_otlp(&trace);
+    let root = &resource_spans.scope_spans[0].spans[0];
+
+    let partial_attr = root.attributes.iter().find(|a| a.key == "rein.run.partial");
+
+    assert!(
+        partial_attr.is_some(),
+        "partial trace must have rein.run.partial attribute on root span; attributes: {:?}",
+        root.attributes
+    );
+    assert_eq!(
+        partial_attr.unwrap().value.string_value.as_deref(),
+        Some("true"),
+        "rein.run.partial must be \"true\""
+    );
+}
+
+// Normal (non-partial) trace must NOT have rein.run.partial attribute.
+#[test]
+fn non_partial_trace_has_no_partial_attribute() {
+    let trace = sample_trace();
+    assert!(!trace.is_partial, "sample_trace() must not be partial");
+
+    let resource_spans = to_otlp(&trace);
+    let root = &resource_spans.scope_spans[0].spans[0];
+
+    assert!(
+        root.attributes.iter().all(|a| a.key != "rein.run.partial"),
+        "non-partial trace must not have rein.run.partial; attributes: {:?}",
+        root.attributes
+    );
+}

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -485,8 +485,7 @@ fn run_error_config_error_roundtrips() {
 #[test]
 fn run_error_serializes_as_snake_case() {
     // Unit variants use #[serde(rename_all = "snake_case")] and serialize as
-    // bare strings, preserving the existing wire format. Only the `Timeout`
-    // struct variant serializes as an object `{"timeout": {...}}`.
+    // bare strings, preserving the existing wire format.
     let v: serde_json::Value = serde_json::to_value(RunError::BudgetExceeded).expect("serialize");
     assert_eq!(v, "budget_exceeded");
 
@@ -506,15 +505,34 @@ fn run_error_timeout_roundtrips() {
         partial_trace: RunTrace::from_events(vec![]),
     };
     let json = serde_json::to_string(&err).expect("serialize");
-    // Without a `tag`, serde serializes a struct variant as {"<variant>": {<fields>}}.
-    // The key is the snake_case variant name and the value contains `partial_trace`.
+    // partial_trace carries #[serde(skip)], so Timeout serializes as
+    // {"timeout": {}} — an object with an empty body.
     let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
     assert!(
         v["timeout"].is_object(),
-        "expected {{\"timeout\": {{...}}}} shape, got: {v}"
+        "expected {{\"timeout\": {{}}}} shape, got: {v}"
     );
     let back: RunError = serde_json::from_str(&json).expect("deserialize");
     assert!(matches!(back, RunError::Timeout { .. }));
+}
+
+// #426: partial_trace must NOT appear in the serialized RunError::Timeout.
+// It is in-process only and must not leak trace events onto the wire.
+#[test]
+fn run_error_timeout_partial_trace_not_on_wire() {
+    let err = RunError::Timeout {
+        partial_trace: RunTrace::from_events(vec![RunEvent::RunComplete {
+            total_cost_cents: 1,
+            total_tokens: 10,
+        }]),
+    };
+    let v: serde_json::Value = serde_json::to_value(&err).expect("serialize");
+    assert!(
+        v.get("timeout")
+            .and_then(|t| t.get("partial_trace"))
+            .is_none(),
+        "partial_trace must not appear in serialized RunError; got: {v}"
+    );
 }
 
 // ── RunTrace output ────────────────────────────────────────────────────────

--- a/src/runtime/workflow/mod.rs
+++ b/src/runtime/workflow/mod.rs
@@ -110,6 +110,12 @@ pub enum WorkflowError {
         stage: String,
         error: super::RunError,
     },
+    /// A stage timed out. This is a hard error — the workflow is aborted
+    /// immediately rather than treating the timeout as a soft step failure.
+    StageTimedOut {
+        stage: String,
+        partial_trace: super::RunTrace,
+    },
     /// A route references a stage that doesn't exist.
     StageNotFound(String),
     /// State persistence failed (save/load/clear).
@@ -130,6 +136,9 @@ impl std::fmt::Display for WorkflowError {
             Self::AgentNotFound(name) => write!(f, "agent not found: {name}"),
             Self::StageFailed { stage, error } => {
                 write!(f, "stage '{stage}' failed: {error}")
+            }
+            Self::StageTimedOut { stage, .. } => {
+                write!(f, "stage '{stage}' timed out")
             }
             Self::StageNotFound(name) => write!(f, "route target stage not found: {name}"),
             Self::PersistenceFailure(msg) => write!(f, "state persistence failed: {msg}"),
@@ -170,12 +179,15 @@ impl WorkflowError {
             // deps, circular routes, missing route targets) mean the graph
             // itself is malformed — silently absorbing them hides operator
             // misconfiguration. State persistence failure risks data corruption.
+            // Provider timeout is hard: a hung provider will likely hang the
+            // next stage too — abort early rather than silently continuing.
             Self::ApprovalRejected { .. }
             | Self::ApprovalTimedOut { .. }
             | Self::CyclicDependency(_)
             | Self::CircularRoute(_)
             | Self::PersistenceFailure(_)
-            | Self::StageNotFound(_) => true,
+            | Self::StageNotFound(_)
+            | Self::StageTimedOut { .. } => true,
             // Soft — step is recorded as failed; dependents are skipped.
             Self::AgentNotFound(_) | Self::StageFailed { .. } => false,
         }
@@ -207,13 +219,21 @@ pub(super) async fn run_stage(
         ctx.config.clone(),
     );
 
-    let result = engine
-        .run(input)
-        .await
-        .map_err(|e| WorkflowError::StageFailed {
-            stage: stage_name.to_string(),
-            error: e,
-        })?;
+    let result = engine.run(input).await.map_err(|e| {
+        // #427: propagate timeout as a hard error so the workflow aborts
+        // immediately rather than silently continuing to the next stage.
+        if let super::RunError::Timeout { partial_trace } = e {
+            WorkflowError::StageTimedOut {
+                stage: stage_name.to_string(),
+                partial_trace,
+            }
+        } else {
+            WorkflowError::StageFailed {
+                stage: stage_name.to_string(),
+                error: e,
+            }
+        }
+    })?;
 
     let events = result.trace.events;
     Ok((

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -3016,3 +3016,67 @@ async fn cascade_skip_propagates_three_hops() {
         "expected StepSkipped for step_c (transitive); events: {events:?}"
     );
 }
+
+// #427: RunError::Timeout inside a workflow stage must propagate as a hard error
+// (WorkflowError::StageTimedOut) that aborts the workflow immediately, rather
+// than being treated as a soft StageFailed that would allow subsequent stages to run.
+#[tokio::test(start_paused = true)]
+async fn stage_timeout_in_workflow_is_hard_error() {
+    use crate::runtime::provider::Message;
+    use crate::runtime::provider::Provider;
+    use crate::runtime::provider::ProviderError;
+    use crate::runtime::provider::ToolDef;
+
+    struct HangingProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for HangingProvider {
+        fn name(&self) -> &'static str {
+            "hanging"
+        }
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolDef],
+        ) -> Result<ChatResponse, ProviderError> {
+            std::future::pending().await
+        }
+    }
+
+    let source = r#"
+        agent slow { model: openai }
+        agent fast { model: openai }
+    "#;
+    let file = parse_file(source);
+    let workflow = make_workflow("pipe", "go", &["slow", "fast"]);
+    let executor = MockExecutor::new();
+    let provider = HangingProvider;
+    let ctx = WorkflowContext {
+        file: &file,
+        provider: &provider,
+        executor: &executor,
+        tool_defs: &[],
+        config: &RunConfig {
+            stage_timeout_secs: Some(5),
+            ..RunConfig::default()
+        },
+        approval_handler: None,
+        audit_log: None,
+        workflow_name: None,
+    };
+
+    let result = run_sequential(&workflow, &ctx).await;
+
+    // Must be an error (not Ok) — the timeout must abort the workflow.
+    assert!(
+        result.is_err(),
+        "expected error from timed-out stage; got Ok"
+    );
+    let err = result.unwrap_err();
+
+    // Must be a hard error: StageTimedOut, NOT StageFailed.
+    assert!(
+        matches!(err, WorkflowError::StageTimedOut { .. }),
+        "timeout inside workflow stage must produce StageTimedOut (hard error); got: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- **#424**: Add multi-turn timeout test (`HangAfterFirstProvider` succeeds turn 0 with tool call, hangs on turn 1); asserts partial trace contains prior `LlmCall` + `StageTimeout { turn: 1 }`
- **#425**: Fix `rein.stage.turn` OTEL sentinel from `unwrap_or(-1)` → `unwrap_or(i64::MAX)`, consistent with `rein.stage.timeout_secs`
- **#426**: Add `#[serde(skip)]` to `partial_trace` in `RunError::Timeout`; add `Default` to `RunTrace`; partial trace no longer leaks onto the wire
- **#427**: Propagate `RunError::Timeout` as `WorkflowError::StageTimedOut` (hard error) in `run_stage()` — hung provider now aborts workflow immediately instead of soft-failing to the next stage
- **#430**: Add `is_partial: bool` to `StructuredTrace`; `export_partial` sets it `true`; `to_otlp` adds `rein.run.partial = "true"` attribute to root span

## Test plan
- [x] Red tests written first (TDD)
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Format clean: `cargo fmt --check`
- [x] No regressions

Closes #424
Closes #425
Closes #426
Closes #427
Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)