### PR TITLE
refactor: engine cleanup — inline helper, non_exhaustive variants, OTEL doc, RunEvent example

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -301,7 +301,7 @@ fn run_engine(engine: &rein::runtime::engine::AgentEngine<'_>, user_message: &st
             eprintln!("Duration: {duration:.2?}");
             0
         }
-        Err(rein::runtime::RunError::Timeout { partial_trace }) => {
+        Err(rein::runtime::RunError::Timeout { partial_trace, .. }) => {
             eprintln!();
             eprintln!(
                 "Run timed out: a provider call did not respond within the configured timeout."

--- a/src/runtime/circuit_breaker/mod.rs
+++ b/src/runtime/circuit_breaker/mod.rs
@@ -86,7 +86,7 @@ impl CircuitBreaker {
             BreakerState::Open => Err(format!(
                 "Circuit breaker '{}' is open: {} failures in window exceeded threshold of {}",
                 self.name,
-                self.count_recent_failures(),
+                self.failure_count(),
                 self.failure_threshold
             )),
         }
@@ -114,7 +114,7 @@ impl CircuitBreaker {
             return;
         }
 
-        if self.count_recent_failures() >= self.failure_threshold {
+        if self.failure_count() >= self.failure_threshold {
             self.state = BreakerState::Open;
             self.opened_at = Some(now);
         }
@@ -129,18 +129,13 @@ impl CircuitBreaker {
     /// Current failure count within the rolling window.
     #[must_use]
     pub fn failure_count(&self) -> u32 {
-        self.count_recent_failures()
+        self.failures.len().try_into().unwrap_or(u32::MAX)
     }
 
     /// The configured failure threshold at which the breaker trips open.
     #[must_use]
     pub fn threshold(&self) -> u32 {
         self.failure_threshold
-    }
-
-    /// Count failures within the current window.
-    fn count_recent_failures(&self) -> u32 {
-        self.failures.len().try_into().unwrap_or(u32::MAX)
     }
 
     /// Remove failures older than the window.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -52,6 +52,20 @@ pub struct ToolResult {
 /// This enum is `#[non_exhaustive]`: new variants may be added in minor
 /// versions without a semver major bump. Downstream crates that `match` on
 /// `RunEvent` must include a wildcard (`_ => {}`) arm.
+///
+/// # Downstream usage
+/// ```rust,ignore
+/// // In a crate that depends on `rein`:
+/// use rein::runtime::RunEvent;
+///
+/// fn handle(event: RunEvent) {
+///     match event {
+///         RunEvent::LlmCall { cost_cents, .. } => { /* ... */ }
+///         RunEvent::StepFailed { step, reason } => { /* ... */ }
+///         _ => {} // required — new variants may be added in minor versions
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -537,6 +551,7 @@ pub enum RunError {
     /// treats struct variants differently from unit variants even when all
     /// fields are skipped. Consumers that pattern-match on the raw JSON shape
     /// must update their deserialization logic.
+    #[non_exhaustive]
     BudgetExceeded {
         #[serde(skip)]
         partial_trace: RunTrace,
@@ -556,6 +571,7 @@ pub enum RunError {
     /// serializes as `{"circuit_breaker_open": {}}` (an object with an empty
     /// body). Consumers that pattern-match on the raw JSON shape must update
     /// their deserialization logic.
+    #[non_exhaustive]
     CircuitBreakerOpen {
         #[serde(skip)]
         partial_trace: RunTrace,
@@ -574,6 +590,7 @@ pub enum RunError {
     /// serialized its events on the wire as `{"timeout": {"events": [...]}}`.
     /// It now serializes as `{"timeout": {}}` (empty object). Consumers that
     /// deserialize the raw JSON shape must update their logic.
+    #[non_exhaustive]
     Timeout {
         #[serde(skip)]
         partial_trace: RunTrace,

--- a/src/runtime/otel_export/mod.rs
+++ b/src/runtime/otel_export/mod.rs
@@ -418,6 +418,11 @@ fn event_to_span_data(event: &super::RunEvent) -> (String, Vec<OtelAttribute>) {
         RunEvent::StageTimeout { turn, timeout_secs } => (
             "rein.stage.timeout".to_string(),
             vec![
+                // `rein.stage.turn` is intentionally 0-indexed — it stores the
+                // raw loop-counter value for machine consumers (OTEL dashboards,
+                // alerting rules). The human-readable summary adds +1 for display
+                // (see `summarize_event`). Do not change this to 1-indexed: it
+                // would break existing OTEL queries.
                 // -1 signals overflow (same convention as rein.step.index): both
                 // turn and timeout_secs are non-negative in domain, so -1 is
                 // clearly out-of-range and distinguishable from a legitimate value.


### PR DESCRIPTION
## Summary

- **#488** — Delete private `count_recent_failures()` wrapper in `CircuitBreaker`; inline `failures.len().try_into().unwrap_or(u32::MAX)` directly into `failure_count()`, `check()`, and `record_failure()`. The wrapper added an indirection with no encapsulation benefit.
- **#489** — Mark `RunError::BudgetExceeded`, `CircuitBreakerOpen`, and `Timeout` variants `#[non_exhaustive]`. External crates can no longer construct a fake `partial_trace` by naming the field — they can only pattern-match with `..`. Within-crate match arm in `run.rs` updated with `..`.
- **#491** — Add comment at the `rein.stage.turn` OTEL emit site documenting that the value is intentionally 0-indexed for machine consumers, and that the human-readable summary adds +1. Prevents future contributors from "fixing" the indexing and breaking existing OTEL queries.
- **#492** — Add `rust,ignore` doc example to `RunEvent` showing downstream consumers the required `_ => {}` wildcard arm when matching on a `#[non_exhaustive]` enum.

## Test plan
- [x] All existing tests pass: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] `cargo fmt --check` clean
- [x] No regressions — #488 is a pure refactor, behavior unchanged

Closes #488, #489, #491, #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)