### PR TITLE
docs: clarify StepStarted.index ordering and generate_id() clock fallback

### DIFF
--- a/src/runtime/audit/mod.rs
+++ b/src/runtime/audit/mod.rs
@@ -201,6 +201,14 @@ impl AuditLog {
     /// Combines a nanosecond wall-clock timestamp with a process-local atomic
     /// sequence number so IDs remain unique even when two events are generated
     /// within the same nanosecond (e.g. in parallel workflow steps or tests).
+    ///
+    /// **Clock-before-epoch fallback:** if the system clock is set before the
+    /// Unix epoch (e.g. RTC not set, certain CI containers), `duration_since`
+    /// returns an error and `unwrap_or_default()` substitutes 0 nanoseconds.
+    /// IDs remain unique because the atomic sequence counter still increments,
+    /// but the hex timestamp prefix will be `0` rather than a real timestamp.
+    /// Compliance consumers that parse the prefix for time ordering should treat
+    /// `audit-0-N` IDs as having unknown wall-clock time.
     pub fn generate_id() -> String {
         use std::time::{SystemTime, UNIX_EPOCH};
         let nanos = SystemTime::now()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -139,6 +139,11 @@ pub enum RunEvent {
         condition: String,
     },
     /// A workflow step is about to begin execution.
+    ///
+    /// `index` is the **topological execution order** (0-based), which may differ
+    /// from the step's declaration order in the `.rein` file when `depends_on` is
+    /// used. Skipped steps do not emit `StepStarted`, so `index` values in a trace
+    /// may not be contiguous.
     StepStarted {
         step: String,
         index: usize,


### PR DESCRIPTION
## Summary
- `StepStarted.index` doc: clarifies it is topological execution order (not declaration order); skipped steps do not emit the event so indices may be non-contiguous (#405)
- `AuditLog::generate_id()` doc: documents clock-before-epoch fallback behavior — IDs remain unique via atomic counter but hex prefix becomes `0`, compliance consumers should treat `audit-0-N` as having unknown wall-clock time (#451)
- Closes #404 (two-step StepStarted index tests already present in master from prior PR)

## Test plan
- [ ] All tests green: `cargo test --all-targets`
- [ ] Clippy clean: `cargo clippy -- -D warnings`
- [ ] fmt: `cargo fmt --check`
- [ ] Docs-only change: no behaviour modified

Closes #404
Closes #405
Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)