### PR TITLE
fix(approval): cap agent_output in WebhookApprovalHandler and SlackApprovalHandler

### DIFF
--- a/src/runtime/approval/mod.rs
+++ b/src/runtime/approval/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::ast::{ApprovalDef, ApprovalKind};
@@ -149,6 +150,25 @@ pub fn parse_timeout(s: &str) -> Option<u64> {
     }
 }
 
+/// Truncate `output` to [`AuditingApprovalHandler::AGENT_OUTPUT_PREVIEW_LIMIT`] bytes,
+/// appending [`AuditingApprovalHandler::TRUNCATION_MARKER`] when a cut is made.
+///
+/// Returns a borrowed `Cow` (no allocation) when the output is within the limit;
+/// returns an owned `Cow` (one allocation) only when truncation is required.
+fn truncate_agent_output(output: &str) -> Cow<'_, str> {
+    let limit = AuditingApprovalHandler::AGENT_OUTPUT_PREVIEW_LIMIT;
+    if output.len() > limit {
+        let cut = output.floor_char_boundary(limit);
+        Cow::Owned(format!(
+            "{}{}",
+            &output[..cut],
+            AuditingApprovalHandler::TRUNCATION_MARKER
+        ))
+    } else {
+        Cow::Borrowed(output)
+    }
+}
+
 /// A webhook-based approval handler.
 ///
 /// POSTs a JSON payload (including the agent's output) to the configured URL.
@@ -180,18 +200,11 @@ impl ApprovalHandler for WebhookApprovalHandler {
     ) -> ApprovalStatus {
         // Cap agent_output to match AuditingApprovalHandler's preview limit so
         // webhook payloads are consistent with audit records (#500).
-        let limit = AuditingApprovalHandler::AGENT_OUTPUT_PREVIEW_LIMIT;
-        let marker = AuditingApprovalHandler::TRUNCATION_MARKER;
-        let output_preview = if agent_output.len() > limit {
-            let cut = agent_output.floor_char_boundary(limit);
-            format!("{}{}", &agent_output[..cut], marker)
-        } else {
-            agent_output.to_string()
-        };
+        let output_preview = truncate_agent_output(agent_output);
         let payload = serde_json::json!({
             "step": step_name,
             "channel": approval.channel,
-            "agent_output": output_preview,
+            "agent_output": &*output_preview,
         });
 
         match self.client.post(&self.url).json(&payload).send().await {
@@ -253,14 +266,7 @@ impl ApprovalHandler for SlackApprovalHandler {
     ) -> ApprovalStatus {
         // Cap agent_output to match AuditingApprovalHandler's preview limit so
         // Slack messages are consistent with audit records (#500).
-        let limit = AuditingApprovalHandler::AGENT_OUTPUT_PREVIEW_LIMIT;
-        let marker = AuditingApprovalHandler::TRUNCATION_MARKER;
-        let output_preview = if agent_output.len() > limit {
-            let cut = agent_output.floor_char_boundary(limit);
-            format!("{}{}", &agent_output[..cut], marker)
-        } else {
-            agent_output.to_string()
-        };
+        let output_preview = truncate_agent_output(agent_output);
         let timeout_str = approval.timeout.as_deref().unwrap_or("no timeout");
         let text = format!(
             "Approval required: step '{step_name}'\nTimeout: {timeout_str}\n\nAgent output:\n{output_preview}"
@@ -385,18 +391,13 @@ impl ApprovalHandler for AuditingApprovalHandler {
         requested.workflow = self.workflow_name.clone();
         requested.agent = self.agent_name.clone();
         // Truncate agent_output to AGENT_OUTPUT_PREVIEW_LIMIT bytes to avoid unbounded audit
-        // log growth. floor_char_boundary ensures the slice ends on a valid UTF-8 boundary
-        // even when the input contains multibyte characters.
-        let cut = agent_output.floor_char_boundary(Self::AGENT_OUTPUT_PREVIEW_LIMIT);
+        // log growth. floor_char_boundary (inside truncate_agent_output) ensures the slice
+        // ends on a valid UTF-8 boundary even when the input contains multibyte characters.
         let truncated = agent_output.len() > Self::AGENT_OUTPUT_PREVIEW_LIMIT;
-        let output_preview = if truncated {
-            format!("{}{}", &agent_output[..cut], Self::TRUNCATION_MARKER)
-        } else {
-            agent_output.to_string()
-        };
+        let output_preview = truncate_agent_output(agent_output);
         let mut req_meta = serde_json::json!({
             "channel": approval.channel,
-            "agent_output": output_preview,
+            "agent_output": &*output_preview,
             "agent_output_truncated": truncated,
         });
         if let Some(ref t) = approval.timeout {

--- a/src/runtime/approval/tests.rs
+++ b/src/runtime/approval/tests.rs
@@ -677,14 +677,98 @@ async fn slack_handler_truncates_long_agent_output_in_message() {
 
     let max_len =
         AuditingApprovalHandler::AGENT_OUTPUT_PREVIEW_LIMIT + AuditingApprovalHandler::TRUNCATION_MARKER.len();
-    // The text field contains the full message (header + output); the output
-    // portion must have been truncated.
+    // The Slack text ends with "\n{output_preview}"; extract the output portion
+    // after the fixed prefix and assert its length directly.
+    let output_portion = text
+        .split("\n\nAgent output:\n")
+        .nth(1)
+        .expect("text must contain 'Agent output:' section");
     assert!(
-        !text.contains(&"y".repeat(max_len + 1)),
-        "slack text must not contain full long output; len={}", text.len()
+        output_portion.len() <= max_len,
+        "slack agent_output portion must be <= {} bytes (limit + marker), got {}",
+        max_len,
+        output_portion.len()
     );
     assert!(
-        text.contains(AuditingApprovalHandler::TRUNCATION_MARKER),
-        "slack text must contain TRUNCATION_MARKER when output is long; got: {text:?}"
+        output_portion.ends_with(AuditingApprovalHandler::TRUNCATION_MARKER),
+        "slack agent_output portion must end with TRUNCATION_MARKER; got: {output_portion:?}"
+    );
+}
+
+/// #500: WebhookApprovalHandler must pass through short agent_output unchanged (no marker).
+#[tokio::test]
+async fn webhook_handler_short_agent_output_not_truncated() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/approval"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/approval", server.uri());
+    let handler = WebhookApprovalHandler::new(url.clone());
+    let approval = make_approval_for_channel("webhook", &url);
+
+    let short_output = "short agent output";
+    handler
+        .request_approval("deploy", short_output, &approval)
+        .await;
+
+    let received = server.received_requests().await.unwrap();
+    let body: serde_json::Value =
+        serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
+    let sent_output = body["agent_output"].as_str().expect("agent_output must be present");
+
+    assert_eq!(
+        sent_output, short_output,
+        "short output must be forwarded verbatim — no truncation marker"
+    );
+    assert!(
+        !sent_output.contains(AuditingApprovalHandler::TRUNCATION_MARKER),
+        "short output must not contain TRUNCATION_MARKER"
+    );
+}
+
+/// #500: SlackApprovalHandler must pass through short agent_output unchanged (no marker).
+#[tokio::test]
+async fn slack_handler_short_agent_output_not_truncated() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/slack"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/slack", server.uri());
+    let handler = SlackApprovalHandler::new(url.clone());
+    let approval = make_approval_for_channel("slack", &url);
+
+    let short_output = "short agent output";
+    handler
+        .request_approval("notify", short_output, &approval)
+        .await;
+
+    let received = server.received_requests().await.unwrap();
+    let body: serde_json::Value =
+        serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
+    let text = body["text"].as_str().expect("text field must be present");
+
+    let output_portion = text
+        .split("\n\nAgent output:\n")
+        .nth(1)
+        .expect("text must contain 'Agent output:' section");
+    assert_eq!(
+        output_portion, short_output,
+        "short output must appear verbatim in Slack message — no truncation marker"
+    );
+    assert!(
+        !output_portion.contains(AuditingApprovalHandler::TRUNCATION_MARKER),
+        "short output must not contain TRUNCATION_MARKER in Slack message"
     );
 }


### PR DESCRIPTION
## Summary

- `AuditingApprovalHandler` already truncates `agent_output` at 512 bytes in audit records; `WebhookApprovalHandler` and `SlackApprovalHandler` were sending full (unbounded) output in outbound payloads — inconsistent with audit records
- Apply the same `AGENT_OUTPUT_PREVIEW_LIMIT` + `TRUNCATION_MARKER` truncation in both handlers before including `agent_output` in the POST body / Slack message text
- Uses `floor_char_boundary` for UTF-8-safe slicing (same approach as `AuditingApprovalHandler`)
- Tests added with `wiremock` to capture and assert the truncated payload shape

## Test plan

- [x] Red tests written first (TDD)
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)