### PR TITLE
feat(audit): is_clock_reliable sentinel + bare-path probe fallback (#497, #499)

### DIFF
--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -197,6 +197,9 @@ mod tests {
         .unwrap();
 
         let code = run_cost(&[tmp.path().to_path_buf()]);
-        assert_eq!(code, 0, "run_cost must succeed even when traces contain timeouts");
+        assert_eq!(
+            code, 0,
+            "run_cost must succeed even when traces contain timeouts"
+        );
     }
 }

--- a/src/runtime/approval/tests.rs
+++ b/src/runtime/approval/tests.rs
@@ -507,8 +507,7 @@ async fn approval_requested_truncates_long_agent_output() {
     let recorded = entries[0].metadata["agent_output"].as_str().unwrap();
     // The maximum recorded length is AGENT_OUTPUT_PREVIEW_LIMIT bytes + TRUNCATION_MARKER.
     // Both constants are module-level in approval/mod.rs so they stay in sync with production.
-    let max_expected = AGENT_OUTPUT_PREVIEW_LIMIT
-        + TRUNCATION_MARKER.len();
+    let max_expected = AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
     assert!(
         recorded.len() <= max_expected,
         "truncated output must be <= {} chars (limit + marker), got {}",
@@ -554,8 +553,7 @@ async fn approval_requested_truncates_multibyte_boundary_safely() {
     let recorded = entries[0].metadata["agent_output"].as_str().unwrap();
     // Must be valid UTF-8 (guaranteed by the str type), within the bound, and end
     // with the truncation marker.
-    let max_expected = AGENT_OUTPUT_PREVIEW_LIMIT
-        + TRUNCATION_MARKER.len();
+    let max_expected = AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
     assert!(
         recorded.len() <= max_expected,
         "multibyte truncation must be <= {} bytes, got {}",
@@ -629,11 +627,12 @@ async fn webhook_handler_truncates_long_agent_output_in_payload() {
     assert_eq!(received.len(), 1, "expected exactly one POST");
     let body: serde_json::Value =
         serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
-    let sent_output = body["agent_output"].as_str().expect("agent_output must be present");
+    let sent_output = body["agent_output"]
+        .as_str()
+        .expect("agent_output must be present");
 
     // The sent output must not exceed the preview limit + marker.
-    let max_len =
-        AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
+    let max_len = AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
     assert!(
         sent_output.len() <= max_len,
         "webhook agent_output must be truncated; got {} bytes (limit {})",
@@ -675,8 +674,7 @@ async fn slack_handler_truncates_long_agent_output_in_message() {
         serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
     let text = body["text"].as_str().expect("text field must be present");
 
-    let max_len =
-        AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
+    let max_len = AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
     // The Slack text ends with "\n{output_preview}"; extract the output portion
     // after the fixed prefix and assert its length directly.
     let output_portion = text
@@ -720,7 +718,9 @@ async fn webhook_handler_short_agent_output_not_truncated() {
     let received = server.received_requests().await.unwrap();
     let body: serde_json::Value =
         serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
-    let sent_output = body["agent_output"].as_str().expect("agent_output must be present");
+    let sent_output = body["agent_output"]
+        .as_str()
+        .expect("agent_output must be present");
 
     assert_eq!(
         sent_output, short_output,
@@ -804,7 +804,9 @@ async fn webhook_handler_truncates_multibyte_boundary_safely() {
     let received = server.received_requests().await.unwrap();
     let body: serde_json::Value =
         serde_json::from_slice(&received[0].body).expect("body must be valid JSON");
-    let sent_output = body["agent_output"].as_str().expect("agent_output must be present");
+    let sent_output = body["agent_output"]
+        .as_str()
+        .expect("agent_output must be present");
 
     let max_len = AGENT_OUTPUT_PREVIEW_LIMIT + TRUNCATION_MARKER.len();
     assert!(
@@ -913,9 +915,17 @@ async fn resolve_handler_webhook_with_audit_log_emits_audit_entries_on_2xx() {
         entries.len()
     );
     assert_eq!(entries[0].kind, AuditKind::ApprovalRequested);
-    assert_eq!(entries[0].step.as_deref(), Some("deploy"), "step must be set on ApprovalRequested");
+    assert_eq!(
+        entries[0].step.as_deref(),
+        Some("deploy"),
+        "step must be set on ApprovalRequested"
+    );
     assert_eq!(entries[1].kind, AuditKind::ApprovalResolved);
-    assert_eq!(entries[1].step.as_deref(), Some("deploy"), "step must be set on ApprovalResolved");
+    assert_eq!(
+        entries[1].step.as_deref(),
+        Some("deploy"),
+        "step must be set on ApprovalResolved"
+    );
     assert_eq!(entries[1].metadata["decision"], "approved");
 }
 
@@ -963,8 +973,16 @@ async fn resolve_handler_slack_with_audit_log_emits_audit_entries_on_2xx() {
         entries.len()
     );
     assert_eq!(entries[0].kind, AuditKind::ApprovalRequested);
-    assert_eq!(entries[0].step.as_deref(), Some("notify"), "step must be set on ApprovalRequested");
+    assert_eq!(
+        entries[0].step.as_deref(),
+        Some("notify"),
+        "step must be set on ApprovalRequested"
+    );
     assert_eq!(entries[1].kind, AuditKind::ApprovalResolved);
-    assert_eq!(entries[1].step.as_deref(), Some("notify"), "step must be set on ApprovalResolved");
+    assert_eq!(
+        entries[1].step.as_deref(),
+        Some("notify"),
+        "step must be set on ApprovalResolved"
+    );
     assert_eq!(entries[1].metadata["decision"], "approved");
 }

--- a/src/runtime/audit/mod.rs
+++ b/src/runtime/audit/mod.rs
@@ -19,6 +19,20 @@ fn default_true() -> bool {
     true
 }
 
+/// Returns `true` if `*v` is `true`.
+///
+/// Used as `skip_serializing_if` predicate for `is_clock_reliable` so that
+/// the field is omitted from serialized JSON when the clock is reliable (the
+/// common case). Combined with `default = "default_true"`, absent fields
+/// round-trip correctly for both old and new entries.
+///
+/// `bool` is `Copy`, but serde's `skip_serializing_if` always passes `&T`,
+/// so the `&bool` argument is unavoidable here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_true(v: &bool) -> bool {
+    *v
+}
+
 /// A single audit log entry.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AuditEntry {
@@ -46,8 +60,10 @@ pub struct AuditEntry {
     /// so compliance consumers must not rely on it for time ordering.
     ///
     /// Deserializes as `true` when the field is absent (entries produced before
-    /// this field was added are assumed reliable).
-    #[serde(default = "default_true")]
+    /// this field was added are assumed reliable). Omitted from serialized JSON
+    /// when `true` (the common case) to keep audit lines compact; always
+    /// written when `false` so compliance consumers can detect the anomaly.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub is_clock_reliable: bool,
 }
 
@@ -159,10 +175,7 @@ impl AuditLog {
         // immediately removed so it leaves no side effect.
         // Use generate_id() suffix to avoid collisions when multiple processes
         // or parallel test threads create audit logs in the same directory.
-        let probe = probe_dir.join(format!(
-            ".rein-audit-probe-{}",
-            Self::generate_id().0
-        ));
+        let probe = probe_dir.join(format!(".rein-audit-probe-{}", Self::generate_id().0));
         fs::File::create(&probe)?;
         // Cleanup is best-effort: writability is already confirmed by the
         // successful create above. If remove_file fails (e.g. the file was

--- a/src/runtime/audit/tests.rs
+++ b/src/runtime/audit/tests.rs
@@ -158,6 +158,15 @@ fn new_with_bare_filename_succeeds() {
     // A bare filename ("audit.jsonl") has parent() == Some(""), which is
     // functionally None. The probe must fall back to cwd rather than
     // silently skipping the writability check.
+    //
+    // Why this test uses cwd instead of a TempDir:
+    // `std::env::set_current_dir` is process-global and not safe to use in
+    // parallel tests. Bare-filename behavior is inherently cwd-dependent by
+    // design — the test exercises the production contract (cwd must be
+    // writable), which holds in all normal test environments. CI runners that
+    // execute in read-only directories will fail this test, which is the
+    // correct signal: a read-only cwd is a misconfiguration, not a test bug.
+    //
     // We don't want to litter cwd with a real log file, so we use a
     // uniquely-named path and verify it doesn't get created (lazy init).
     let (id, _) = AuditLog::generate_id();

--- a/src/runtime/workflow/tests.rs
+++ b/src/runtime/workflow/tests.rs
@@ -3446,8 +3446,7 @@ async fn mixed_workflow_final_output_retains_stage_output_when_all_steps_fail() 
     // final_output must be the stage output, not an empty string from the
     // failed step (which has is_real_execution() == false).
     assert_eq!(
-        result.final_output,
-        "stage output",
+        result.final_output, "stage output",
         "final_output must retain stage output when all steps fail; got: {:?}",
         result.final_output
     );


### PR DESCRIPTION
## Summary
- **#497**: `AuditLog::generate_id()` now returns `(String, bool)` — the bool is `false` when the system clock is before the Unix epoch. `AuditEntry` gains `is_clock_reliable: bool` (`#[serde(default = "default_true")]`), letting compliance consumers detect entries whose hex timestamp prefix is unreliable. Backward-compat: old JSON without the field deserializes as `true`.
- **#499**: `AuditLog::new` previously silently skipped the writability probe when `path.parent()` returned `None` or an empty path (bare filename like `"audit.jsonl"`). It now explicitly falls back to `current_dir()` so the probe is always performed against a real directory.

## Test plan
- [x] Red tests written first (TDD) — 4 new tests for #497, 1 for #499
- [x] All 16 audit tests green: `cargo test runtime::audit`
- [x] Full suite green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions

Closes #497
Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)