### PR TITLE
refactor(audit,approval): extract generate_id to module level; pub(crate) truncate_agent_output (#529, #523)

### DIFF
--- a/src/runtime/approval/mod.rs
+++ b/src/runtime/approval/mod.rs
@@ -171,7 +171,11 @@ pub fn parse_timeout(s: &str) -> Option<u64> {
 /// Returns a borrowed `Cow` (no allocation) when the output is within the limit;
 /// returns an owned `Cow` (one allocation) only when truncation is required.
 /// Callers can detect truncation via `matches!(result, Cow::Owned(_))`.
-fn truncate_agent_output(output: &str) -> Cow<'_, str> {
+///
+/// Exposed as `pub(crate)` so that integration tests and other modules within
+/// the crate can construct the same truncated fixtures as the production
+/// handlers without duplicating the truncation logic.
+pub(crate) fn truncate_agent_output(output: &str) -> Cow<'_, str> {
     if output.len() > AGENT_OUTPUT_PREVIEW_LIMIT {
         let cut = output.floor_char_boundary(AGENT_OUTPUT_PREVIEW_LIMIT);
         Cow::Owned(format!("{}{}", &output[..cut], TRUNCATION_MARKER))

--- a/src/runtime/audit/mod.rs
+++ b/src/runtime/audit/mod.rs
@@ -175,7 +175,7 @@ impl AuditLog {
         // immediately removed so it leaves no side effect.
         // Use generate_id() suffix to avoid collisions when multiple processes
         // or parallel test threads create audit logs in the same directory.
-        let probe = probe_dir.join(format!(".rein-audit-probe-{}", Self::generate_id().0));
+        let probe = probe_dir.join(format!(".rein-audit-probe-{}", generate_id().0));
         fs::File::create(&probe)?;
         // Cleanup is best-effort: writability is already confirmed by the
         // successful create above. If remove_file fails (e.g. the file was
@@ -250,31 +250,35 @@ impl AuditLog {
     pub fn path(&self) -> &Path {
         &self.path
     }
+}
 
-    /// Generate a unique event ID.
-    ///
-    /// Returns `(id, is_clock_reliable)` where `is_clock_reliable` is `false`
-    /// when the system clock is set before the Unix epoch (e.g. RTC not set,
-    /// certain CI containers). In that case the hex timestamp prefix in `id`
-    /// will be `0` rather than a real timestamp; IDs remain unique because the
-    /// atomic sequence counter still increments.
-    ///
-    /// Compliance consumers that parse the prefix for time ordering should
-    /// treat `audit-0-N` IDs (or any entry with `is_clock_reliable: false`)
-    /// as having unknown wall-clock time.
-    pub fn generate_id() -> (String, bool) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let clock_result = SystemTime::now().duration_since(UNIX_EPOCH);
-        let is_clock_reliable = clock_result.is_ok();
-        let nanos = clock_result.unwrap_or_default().as_nanos();
-        let seq = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        (format!("audit-{nanos:x}-{seq}"), is_clock_reliable)
-    }
+/// Generate a unique audit event ID.
+///
+/// Returns `(id, is_clock_reliable)` where `is_clock_reliable` is `false`
+/// when the system clock is set before the Unix epoch (e.g. RTC not set,
+/// certain CI containers). In that case the hex timestamp prefix in `id`
+/// will be `0` rather than a real timestamp; IDs remain unique because the
+/// atomic sequence counter still increments.
+///
+/// Compliance consumers that parse the prefix for time ordering should
+/// treat `audit-0-N` IDs (or any entry with `is_clock_reliable: false`)
+/// as having unknown wall-clock time.
+///
+/// This is a module-level function rather than an `AuditLog` method because
+/// it has no dependency on `AuditLog` state — it reads only the process-global
+/// `ID_COUNTER` and the system clock.
+pub(crate) fn generate_id() -> (String, bool) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let clock_result = SystemTime::now().duration_since(UNIX_EPOCH);
+    let is_clock_reliable = clock_result.is_ok();
+    let nanos = clock_result.unwrap_or_default().as_nanos();
+    let seq = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    (format!("audit-{nanos:x}-{seq}"), is_clock_reliable)
 }
 
 /// Convenience builder for audit entries.
 pub fn entry(kind: AuditKind, description: impl Into<String>) -> AuditEntry {
-    let (id, is_clock_reliable) = AuditLog::generate_id();
+    let (id, is_clock_reliable) = generate_id();
     AuditEntry {
         id,
         timestamp: Utc::now(),

--- a/src/runtime/audit/tests.rs
+++ b/src/runtime/audit/tests.rs
@@ -108,11 +108,27 @@ fn serialization_roundtrip() {
     assert_eq!(parsed.metadata["version"], "2.0");
 }
 
+// --- #529: generate_id extracted to module-level ---
+
+#[test]
+fn module_level_generate_id_produces_unique_ids() {
+    let (id1, _) = generate_id();
+    let (id2, _) = generate_id();
+    assert_ne!(
+        id1, id2,
+        "successive generate_id() calls must produce distinct IDs"
+    );
+    assert!(
+        id1.starts_with("audit-"),
+        "generated ID must have audit- prefix"
+    );
+}
+
 // --- #497 is_clock_reliable sentinel ---
 
 #[test]
 fn generate_id_returns_reliable_true_under_normal_conditions() {
-    let (_id, reliable) = AuditLog::generate_id();
+    let (_id, reliable) = generate_id();
     assert!(
         reliable,
         "system clock is expected to be post-epoch in the test environment"
@@ -169,7 +185,7 @@ fn new_with_bare_filename_succeeds() {
     //
     // We don't want to litter cwd with a real log file, so we use a
     // uniquely-named path and verify it doesn't get created (lazy init).
-    let (id, _) = AuditLog::generate_id();
+    let (id, _) = generate_id();
     let name = format!(".rein-test-bare-{id}.jsonl");
     let log = AuditLog::new(&name);
     // Cleanup probe remnants (if any) — best effort.

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1001,3 +1001,13 @@ fn to_structured_timeout_count_does_not_interfere_with_other_counters() {
         "one ToolCallAttempt must produce tool_calls = 1"
     );
 }
+
+// --- #523: truncate_agent_output is pub(crate) ---
+
+#[test]
+fn truncate_agent_output_is_accessible_from_runtime_module() {
+    use crate::runtime::approval::truncate_agent_output;
+    let short = "hello";
+    let result = truncate_agent_output(short);
+    assert_eq!(&*result, short, "short output must be returned unchanged");
+}


### PR DESCRIPTION
## Summary
- **#529**: `AuditLog::generate_id()` had no dependency on `AuditLog` state. Extracted to `pub(crate)` module-level `generate_id() -> (String, bool)`, removing SRP violation. `AuditLog::new` and `entry()` call the module-level function directly. The public `AuditLog` API surface shrinks by one symbol.
- **#523**: `truncate_agent_output` upgraded from `fn` (module-private) to `pub(crate)` so integration tests and modules outside `runtime::approval` can construct the same truncated fixtures without duplicating the limit/marker logic. Added test in `runtime::tests` verifying accessibility from outside the approval module.

## Test plan
- [x] Red tests written first (TDD) — `module_level_generate_id_produces_unique_ids` + `truncate_agent_output_is_accessible_from_runtime_module`
- [x] All tests green: `cargo test` (794 lib tests)
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Format clean: `cargo fmt --check`
- [x] No regressions

Closes #529
Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)