### PR TITLE
test(approval): add 4xx/5xx webhook reject audit coverage (#525)

### DIFF
--- a/src/runtime/approval/tests.rs
+++ b/src/runtime/approval/tests.rs
@@ -929,6 +929,109 @@ async fn resolve_handler_webhook_with_audit_log_emits_audit_entries_on_2xx() {
     assert_eq!(entries[1].metadata["decision"], "approved");
 }
 
+/// #525: When the webhook endpoint returns 4xx, resolve_approval_handler("webhook")
+/// wrapped in AuditingApprovalHandler must record decision = "rejected" in the
+/// ApprovalResolved audit entry.
+#[tokio::test]
+async fn resolve_handler_webhook_with_audit_log_records_rejected_on_4xx() {
+    use crate::runtime::audit::{AuditKind, AuditLog};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/approval"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let log = Arc::new(AuditLog::new(tmp.path().join("audit.jsonl")).unwrap());
+
+    let url = format!("{}/approval", server.uri());
+    let approval = make_approval_for_channel("webhook", &url);
+    let inner = resolve_approval_handler(&approval);
+    let handler = AuditingApprovalHandler::new(Arc::from(inner), Arc::clone(&log));
+
+    let status = handler
+        .request_approval("deploy", "Agent output here", &approval)
+        .await;
+
+    assert!(
+        matches!(status, ApprovalStatus::Rejected { .. }),
+        "resolved webhook handler must reject on 4xx; got {status:?}"
+    );
+
+    let entries = log.read_all().unwrap();
+    assert_eq!(
+        entries.len(),
+        2,
+        "expected ApprovalRequested + ApprovalResolved; got {} entries",
+        entries.len()
+    );
+    assert_eq!(entries[0].kind, AuditKind::ApprovalRequested);
+    assert_eq!(
+        entries[0].step.as_deref(),
+        Some("deploy"),
+        "step must be set on ApprovalRequested"
+    );
+    assert_eq!(entries[1].kind, AuditKind::ApprovalResolved);
+    assert_eq!(
+        entries[1].step.as_deref(),
+        Some("deploy"),
+        "step must be set on ApprovalResolved"
+    );
+    assert_eq!(
+        entries[1].metadata["decision"], "rejected",
+        "decision must be 'rejected' when webhook returns 4xx"
+    );
+}
+
+/// #525: When the webhook endpoint returns 5xx, AuditingApprovalHandler must
+/// also record decision = "rejected" (fail-closed contract — non-2xx is never approval).
+#[tokio::test]
+async fn resolve_handler_webhook_with_audit_log_records_rejected_on_5xx() {
+    use crate::runtime::audit::{AuditKind, AuditLog};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/approval"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let log = Arc::new(AuditLog::new(tmp.path().join("audit.jsonl")).unwrap());
+
+    let url = format!("{}/approval", server.uri());
+    let approval = make_approval_for_channel("webhook", &url);
+    let inner = resolve_approval_handler(&approval);
+    let handler = AuditingApprovalHandler::new(Arc::from(inner), Arc::clone(&log));
+
+    let status = handler
+        .request_approval("deploy", "Agent output here", &approval)
+        .await;
+
+    assert!(
+        matches!(status, ApprovalStatus::Rejected { .. }),
+        "resolved webhook handler must reject on 5xx; got {status:?}"
+    );
+
+    let entries = log.read_all().unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[1].kind, AuditKind::ApprovalResolved);
+    assert_eq!(
+        entries[1].metadata["decision"], "rejected",
+        "decision must be 'rejected' when webhook returns 5xx"
+    );
+}
+
 /// #511: When approval_handler is None and channel is "slack", resolve_approval_handler
 /// must return a SlackApprovalHandler that, when wrapped by AuditingApprovalHandler,
 /// emits ApprovalRequested + ApprovalResolved audit entries (slack auto-approves on success).


### PR DESCRIPTION
## Summary
- **#525**: The existing #511 tests only covered the 2xx happy path for `resolve_approval_handler("webhook")` wrapped in `AuditingApprovalHandler`. Added two tests covering the non-2xx fail-closed path:
  - `resolve_handler_webhook_with_audit_log_records_rejected_on_4xx` — 403 response; verifies `decision = "rejected"` in audit + step propagation
  - `resolve_handler_webhook_with_audit_log_records_rejected_on_5xx` — 500 response; verifies `decision = "rejected"` in audit

Both tests mirror the 2xx test structure (wiremock server, AuditLog, ApprovalRequested + ApprovalResolved pair).

## Test plan
- [x] Tests are green (verifying existing fail-closed behavior)
- [x] Full suite green: `cargo test --all-targets` (796 tests)
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Format clean: `cargo fmt --check`

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)