### PR TITLE
refactor(audit)/test(cost): named generate_id binding + aggregate timeout test

### DIFF
--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -231,6 +231,22 @@ mod tests {
         );
     }
 
+    /// #534: Stage timeouts line must show the sum across all traces.
+    #[test]
+    fn print_summary_aggregates_timeout_counts_across_traces() {
+        let mut t1 = make_trace("bot1", 100, 500);
+        t1.stats.timeout_count = 3;
+        let mut t2 = make_trace("bot2", 100, 500);
+        t2.stats.timeout_count = 0;
+        let mut buf = Vec::new();
+        print_summary_to(&[t1, t2], &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("Stage timeouts: 3"),
+            "aggregate timeout count must be summed across traces; got:\n{output}"
+        );
+    }
+
     /// #510: run_cost must succeed (exit 0) when traces include StageTimeout events.
     /// Stage timeouts: N is now always printed regardless of count (#520).
     #[test]

--- a/src/runtime/audit/mod.rs
+++ b/src/runtime/audit/mod.rs
@@ -175,7 +175,8 @@ impl AuditLog {
         // immediately removed so it leaves no side effect.
         // Use generate_id() suffix to avoid collisions when multiple processes
         // or parallel test threads create audit logs in the same directory.
-        let probe = probe_dir.join(format!(".rein-audit-probe-{}", generate_id().0));
+        let (probe_id, _) = generate_id();
+        let probe = probe_dir.join(format!(".rein-audit-probe-{probe_id}"));
         fs::File::create(&probe)?;
         // Cleanup is best-effort: writability is already confirmed by the
         // successful create above. If remove_file fails (e.g. the file was


### PR DESCRIPTION
## Summary
- **#532**: Replace `generate_id().0` tuple index with a named binding `let (probe_id, _) = generate_id()` in `AuditLog::new` — makes intent explicit (we only need the ID string, not the reliability bool)
- **#534**: Add `print_summary_aggregates_timeout_counts_across_traces` test verifying that `Stage timeouts:` line shows the sum across multiple traces with mixed zero/non-zero counts

## Test plan
- [x] New test added for #534 aggregate behavior
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions

Closes #532
Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)