### PR TITLE
refactor(approval): extract byte_truncation_cut helper

### DIFF
--- a/src/runtime/approval/mod.rs
+++ b/src/runtime/approval/mod.rs
@@ -153,6 +153,7 @@ pub fn parse_timeout(s: &str) -> Option<u64> {
 /// Both [`truncate_agent_output`] (which appends [`TRUNCATION_MARKER`]) and
 /// [`write_cli_prompt`] (which shows a standalone notice line) call this
 /// helper so the threshold logic has a single source of truth.
+#[must_use]
 fn byte_truncation_cut(output: &str) -> Option<usize> {
     if output.len() > AGENT_OUTPUT_PREVIEW_LIMIT {
         Some(output.floor_char_boundary(AGENT_OUTPUT_PREVIEW_LIMIT))

--- a/src/runtime/approval/tests.rs
+++ b/src/runtime/approval/tests.rs
@@ -1214,3 +1214,70 @@ fn write_cli_prompt_no_truncation_notice_for_short_output() {
         "truncation notice must NOT appear for short output; got:\n{output}"
     );
 }
+
+/// #539: Direct unit tests for `byte_truncation_cut` — the single source of
+/// truth for the truncation threshold. Covers all four meaningful cases so
+/// a future regression at the helper level is caught immediately without
+/// relying solely on indirect coverage through the callers.
+#[test]
+fn byte_truncation_cut_returns_none_for_short_input() {
+    let short = "hello";
+    assert_eq!(
+        byte_truncation_cut(short),
+        None,
+        "input shorter than the limit must return None"
+    );
+}
+
+#[test]
+fn byte_truncation_cut_returns_none_at_exact_limit() {
+    let exact = "x".repeat(AGENT_OUTPUT_PREVIEW_LIMIT);
+    assert_eq!(
+        byte_truncation_cut(&exact),
+        None,
+        "input at exactly the limit must return None (guard is `>`, not `>=`)"
+    );
+}
+
+#[test]
+fn byte_truncation_cut_returns_some_for_long_input() {
+    let long = "x".repeat(AGENT_OUTPUT_PREVIEW_LIMIT + 1);
+    let cut = byte_truncation_cut(&long).expect("input over the limit must return Some");
+    assert!(
+        cut <= AGENT_OUTPUT_PREVIEW_LIMIT,
+        "cut index must not exceed AGENT_OUTPUT_PREVIEW_LIMIT; got {cut}"
+    );
+}
+
+#[test]
+fn byte_truncation_cut_returns_valid_char_boundary_for_multibyte_input() {
+    // Build a string where the AGENT_OUTPUT_PREVIEW_LIMIT-th byte falls in
+    // the middle of a 3-byte UTF-8 codepoint (U+4E2D, '中', encoded as
+    // 0xE4 0xB8 0xAD).  Pad with single-byte 'a' characters so that the
+    // LIMIT-th byte lands inside the codepoint.
+    //
+    // We place the multibyte character starting at byte AGENT_OUTPUT_PREVIEW_LIMIT - 1
+    // so that bytes [LIMIT-1, LIMIT, LIMIT+1] are the three bytes of '中'.
+    // The cut must be at LIMIT-1 (the start of the codepoint), not LIMIT.
+    let prefix_len = AGENT_OUTPUT_PREVIEW_LIMIT - 1;
+    let prefix = "a".repeat(prefix_len);
+    let long = format!("{prefix}中extra");
+    assert!(long.len() > AGENT_OUTPUT_PREVIEW_LIMIT, "test string must exceed limit");
+    let cut = byte_truncation_cut(&long).expect("must return Some for overlong input");
+    // The cut must be at a valid char boundary.
+    assert!(
+        long.is_char_boundary(cut),
+        "cut index {cut} must be a valid char boundary"
+    );
+    // The cut must not exceed the limit.
+    assert!(
+        cut <= AGENT_OUTPUT_PREVIEW_LIMIT,
+        "cut index {cut} must not exceed AGENT_OUTPUT_PREVIEW_LIMIT"
+    );
+    // The cut must be at prefix_len (start of the multibyte codepoint),
+    // not at AGENT_OUTPUT_PREVIEW_LIMIT (which would split the codepoint).
+    assert_eq!(
+        cut, prefix_len,
+        "cut must land at the start of the multibyte codepoint, not mid-codepoint"
+    );
+}


### PR DESCRIPTION
## Summary
- Extracts `fn byte_truncation_cut(output: &str) -> Option<usize>` — returns the `floor_char_boundary` cut index when `output.len() > AGENT_OUTPUT_PREVIEW_LIMIT`, `None` otherwise
- Both `truncate_agent_output` (appends `TRUNCATION_MARKER`) and `write_cli_prompt` (shows standalone notice) now call this shared helper — eliminates parallel threshold logic that was a silent drift hazard

## Test plan
- [x] All existing truncation tests continue to pass (behavior unchanged)
- [x] All tests green: `cargo test --all-targets`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] No regressions

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)